### PR TITLE
fix: `hexFrom` in `@ckb-ccc/core/barrel` not producing valid hex strings when an empty array is provided

### DIFF
--- a/packages/core/src/hex/index.ts
+++ b/packages/core/src/hex/index.ts
@@ -26,5 +26,5 @@ export type HexLike = BytesLike;
  * ```
  */
 export function hexFrom(hex: HexLike): Hex {
-  return `0x${bytesTo(bytesFrom(hex), "hex")}`;
+  return `0x${bytesTo(bytesFrom(hex), "hex") || "0"}`;
 }


### PR DESCRIPTION
```javascript
console.log(hexFrom([])); // outputs "0x"
console.log(hexFrom(new Uint8Array([]))); // outputs "0x"
```        
`hexFrom` will return `0x` which is an invalid hex string when an empty array was provided as argument, since `bytesTo` returns empty string when zero-length bytes was provided.

Illegal hex string like `0x` will be refused by `BigInt` and leads to an exception.

This PR fixes it by providing a default "0" if `bytesTo` returns an empty string.