### PR TITLE
fix: udtBalanceFrom

### DIFF
--- a/.changeset/slimy-pillows-own.md
+++ b/.changeset/slimy-pillows-own.md
@@ -1,0 +1,5 @@
+---
+"@ckb-ccc/core": patch
+---
+
+fix: udtBalanceFrom

--- a/packages/core/src/ckb/transaction.ts
+++ b/packages/core/src/ckb/transaction.ts
@@ -688,10 +688,6 @@ export class WitnessArgs extends mol.Entity.Base<
  */
 export function udtBalanceFrom(dataLike: BytesLike): Num {
   const data = bytesFrom(dataLike).slice(0, 16);
-  if (data.length !== 16) {
-    throw new Error("Invalid UDT cell data");
-  }
-
   return numFromBytes(data);
 }
 


### PR DESCRIPTION
First tx with non-16-bytes udt data happens on testnet https://testnet.explorer.nervos.org/transaction/0xef7a97a132fef4a1d2393b97a9bec38c2babe145d86a372a5e72294f2719881b