### PR TITLE
chore: export codec and cobuild module from spore

### DIFF
--- a/packages/spore/src/index.ts
+++ b/packages/spore/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./cluster/index.js";
+export * from "./cobuild/index.js";
+export * from "./codec/index.js";
 export * as dob from "./dob/index.js";
 export * from "./predefined/index.js";
 export * from "./spore/index.js";

--- a/packages/spore/src/predefined/utils.ts
+++ b/packages/spore/src/predefined/utils.ts
@@ -39,6 +39,22 @@ export function getSporeScriptInfo(
   return SporeScriptInfo.from(scriptInfo);
 }
 
+export function getSporeScriptVersion(
+  client: ccc.Client,
+  scriptLike: Omit<ccc.ScriptLike, "args">,
+): SporeVersion | undefined {
+  const scriptInfos = getSporeScriptInfos(client);
+
+  for (const [version, scriptInfo] of Object.entries(scriptInfos)) {
+    if (
+      scriptInfo?.codeHash === scriptLike.codeHash &&
+      scriptInfo?.hashType === scriptLike.hashType
+    ) {
+      return version as SporeVersion;
+    }
+  }
+}
+
 export function getClusterScriptInfo(
   client: ccc.Client,
   version?: SporeVersion,
@@ -53,4 +69,20 @@ export function getClusterScriptInfo(
   }
 
   return SporeScriptInfo.from(scriptInfo);
+}
+
+export function getClusterScriptVersion(
+  client: ccc.Client,
+  scriptLike: Omit<ccc.ScriptLike, "args">,
+): SporeVersion | undefined {
+  const scriptInfos = getClusterScriptInfos(client);
+
+  for (const [version, scriptInfo] of Object.entries(scriptInfos)) {
+    if (
+      scriptInfo?.codeHash === scriptLike.codeHash &&
+      scriptInfo?.hashType === scriptLike.hashType
+    ) {
+      return version as SporeVersion;
+    }
+  }
 }


### PR DESCRIPTION
# Description

1. codec module is supposed to be exported for individually parsing `SporeData` structure from raw bytes.
2. function of carrying out spore/cluster script version from outside script is supposed to add