### PR TITLE
chore: tiny complete for core & spore

### DIFF
--- a/.changeset/blue-pans-hope.md
+++ b/.changeset/blue-pans-hope.md
@@ -1,0 +1,5 @@
+---
+"@ckb-ccc/spore": minor
+---
+
+support search spore/cluster under customized lock script

--- a/.changeset/gentle-crews-stare.md
+++ b/.changeset/gentle-crews-stare.md
@@ -1,0 +1,5 @@
+---
+"@ckb-ccc/core": minor
+---
+
+Add treatment to uncompatible XUDT data format

--- a/packages/core/src/ckb/transaction.ts
+++ b/packages/core/src/ckb/transaction.ts
@@ -701,11 +701,13 @@ export class WitnessArgs extends mol.Entity.Base<
 }
 
 /**
+ * Convert a bytes to a num.
+ *
  * @public
  */
 export function udtBalanceFrom(dataLike: BytesLike): Num {
   const data = bytesFrom(dataLike).slice(0, 16);
-  return numFromBytes(data);
+  return data.length === 0 ? Zero : numFromBytes(data);
 }
 
 export const RawTransaction = mol.table({


### PR DESCRIPTION
# Description

for `core`:
while developing `ckb-devrel-indexer`, we encountered an abnormal XUDT format, in which the cell data is empty, according to the RFC of XUDT, we always assume its data is larger than 16 bytes, so that incompatible situation should be considered.

for `spore`:
1. I found there would be a demand that searching spore/cluster under a customized lock script, not only for the signers themself, for example, a customized script locked cluster that can provide on-chain user-defined verification on minting spores.
2. an unusual [version](https://github.com/sporeprotocol/spore-contract/blob/master/docs/VERSIONS.md#tag-021-testnet) of spore in testnet has been applied, so adding this version into predefined config