### PR TITLE
bug: support customized spore script for transfer&melt method

### DIFF
--- a/.changeset/curly-berries-watch.md
+++ b/.changeset/curly-berries-watch.md
@@ -1,0 +1,5 @@
+---
+"@ckb-ccc/spore": patch
+---
+
+bug: add scriptInfo parameter in transfer/melt spore method

--- a/packages/spore/src/cluster/index.ts
+++ b/packages/spore/src/cluster/index.ts
@@ -145,17 +145,22 @@ export async function transferSporeCluster(params: {
   id: ccc.HexLike;
   to: ccc.ScriptLike;
   tx?: ccc.TransactionLike;
+  scripts?: SporeScriptInfoLike[];
   scriptInfoHash?: ccc.HexLike;
 }): Promise<{
   tx: ccc.Transaction;
 }> {
-  const { signer, id, to, scriptInfoHash } = params;
+  const { signer, id, to, scripts, scriptInfoHash } = params;
 
   // prepare transaction
   const tx = ccc.Transaction.from(params.tx ?? {});
 
   // build cluster cell
-  const { cell: cluster, scriptInfo } = await assertCluster(signer.client, id);
+  const { cell: cluster, scriptInfo: clusterScriptInfo } = await assertCluster(
+    signer.client,
+    id,
+    scripts,
+  );
 
   tx.addInput(cluster);
   tx.addOutput(
@@ -167,10 +172,10 @@ export async function transferSporeCluster(params: {
   );
 
   // complete cellDeps
-  await tx.addCellDepInfos(signer.client, scriptInfo.cellDeps);
+  await tx.addCellDepInfos(signer.client, clusterScriptInfo.cellDeps);
 
   // generate cobuild action
-  const actions = scriptInfo.cobuild
+  const actions = clusterScriptInfo.cobuild
     ? [
         assembleTransferClusterAction(
           cluster.cellOutput,

--- a/packages/spore/src/spore/index.ts
+++ b/packages/spore/src/spore/index.ts
@@ -164,17 +164,22 @@ export async function transferSpore(params: {
   id: ccc.HexLike;
   to: ccc.ScriptLike;
   tx?: ccc.TransactionLike;
+  scripts?: SporeScriptInfoLike[];
   scriptInfoHash?: ccc.HexLike;
 }): Promise<{
   tx: ccc.Transaction;
 }> {
-  const { signer, id, to, scriptInfoHash } = params;
+  const { signer, id, to, scripts, scriptInfoHash } = params;
 
   // prepare transaction
   const tx = ccc.Transaction.from(params.tx ?? {});
 
-  const { cell: sporeCell, scriptInfo } = await assertSpore(signer.client, id);
-  await tx.addCellDepInfos(signer.client, scriptInfo.cellDeps);
+  const { cell: sporeCell, scriptInfo: sporeScriptInfo } = await assertSpore(
+    signer.client,
+    id,
+    scripts,
+  );
+  await tx.addCellDepInfos(signer.client, sporeScriptInfo.cellDeps);
   tx.addInput(sporeCell);
   tx.addOutput(
     {
@@ -184,7 +189,7 @@ export async function transferSpore(params: {
     sporeCell.outputData,
   );
 
-  const actions = scriptInfo.cobuild
+  const actions = sporeScriptInfo.cobuild
     ? [
         assembleTransferSporeAction(
           sporeCell.cellOutput,
@@ -213,21 +218,26 @@ export async function meltSpore(params: {
   signer: ccc.Signer;
   id: ccc.HexLike;
   tx?: ccc.TransactionLike;
+  scripts?: SporeScriptInfoLike[];
   scriptInfoHash?: ccc.HexLike;
 }): Promise<{
   tx: ccc.Transaction;
 }> {
-  const { signer, id, scriptInfoHash } = params;
+  const { signer, id, scripts, scriptInfoHash } = params;
 
   // prepare transaction
   const tx = ccc.Transaction.from(params.tx ?? {});
 
   // build spore cell
-  const { cell: sporeCell, scriptInfo } = await assertSpore(signer.client, id);
-  await tx.addCellDepInfos(signer.client, scriptInfo.cellDeps);
+  const { cell: sporeCell, scriptInfo: sporeScriptInfo } = await assertSpore(
+    signer.client,
+    id,
+    scripts,
+  );
+  await tx.addCellDepInfos(signer.client, sporeScriptInfo.cellDeps);
   tx.addInput(sporeCell);
 
-  const actions = scriptInfo.cobuild
+  const actions = sporeScriptInfo.cobuild
     ? [assembleMeltSporeAction(sporeCell.cellOutput, scriptInfoHash)]
     : [];
 


### PR DESCRIPTION
# Description

Reported by UTXOGlobal team that methods `transferSpore` and `meltSpore` are not allowed for user-defined spore scripts. To solve this issue, we should expose `ScriptInfoLike` parameter.