### PR TITLE
fix(core): fix molecule option for number zero

### DIFF
--- a/.changeset/fast-spiders-invent.md
+++ b/.changeset/fast-spiders-invent.md
@@ -1,0 +1,5 @@
+---
+"@ckb-ccc/core": patch
+---
+
+fix molecule option for number zero

--- a/packages/core/src/molecule/codec.ts
+++ b/packages/core/src/molecule/codec.ts
@@ -250,7 +250,7 @@ export function option<Encodable, Decoded>(
 ): Codec<Encodable | undefined | null, Decoded | undefined> {
   return Codec.from({
     encode(userDefinedOrNull) {
-      if (!userDefinedOrNull) {
+      if (userDefinedOrNull === undefined || userDefinedOrNull === null) {
         return bytesFrom([]);
       }
       try {


### PR DESCRIPTION
```js
    let ret = mol.Uint8Opt.encode(0);
    console.log(`ret:${JSON.stringify(ret)}`);
```
The result is `None`(empty) which is unexpected.
