### PR TITLE
fix(joy-id): resolve race condition in Bitcoin signer connection storage

### DIFF
--- a/packages/joy-id/src/btc/index.ts
+++ b/packages/joy-id/src/btc/index.ts
@@ -145,7 +145,7 @@ export class BitcoinSigner extends ccc.SignerBtc {
     };
     await Promise.all([
       this.connectionsRepo.set(
-        { uri: config.joyidAppURL, addressType: `btc-${res.btcAddressType}` },
+        { uri: config.joyidAppURL, addressType: `btc-${this.addressType}` },
         this.connection,
       ),
       this.connectionsRepo.set(

--- a/packages/joy-id/src/connectionsStorage/index.ts
+++ b/packages/joy-id/src/connectionsStorage/index.ts
@@ -72,6 +72,8 @@ export interface ConnectionsRepo {
  * Class representing a local storage-based repository for managing connections.
  */
 export class ConnectionsRepoLocalStorage implements ConnectionsRepo {
+  private operationLock: Promise<void> = Promise.resolve();
+
   /**
    * Creates an instance of ConnectionsRepoLocalStorage.
    * @param [storageKey="ccc-joy-id-signer"] - The local storage key.
@@ -110,23 +112,28 @@ export class ConnectionsRepoLocalStorage implements ConnectionsRepo {
     selector: AccountSelector,
     connection: Connection | undefined,
   ): Promise<void> {
-    const connections = await this.readConnections();
+    // Use a lock to prevent race conditions during concurrent set operations
+    this.operationLock = this.operationLock.then(async () => {
+      const connections = await this.readConnections();
 
-    if (connection) {
-      const existed = connections.find(([s]) => isSelectorMatch(s, selector));
-      if (existed) {
-        existed[1] = connection;
+      if (connection) {
+        const existed = connections.find(([s]) => isSelectorMatch(s, selector));
+        if (existed) {
+          existed[1] = connection;
+        } else {
+          connections.push([selector, connection]);
+        }
+        window.localStorage.setItem(this.storageKey, JSON.stringify(connections));
       } else {
-        connections.push([selector, connection]);
+        window.localStorage.setItem(
+          this.storageKey,
+          JSON.stringify(
+            connections.filter(([s]) => !isSelectorMatch(s, selector)),
+          ),
+        );
       }
-      window.localStorage.setItem(this.storageKey, JSON.stringify(connections));
-    } else {
-      window.localStorage.setItem(
-        this.storageKey,
-        JSON.stringify(
-          connections.filter(([s]) => !isSelectorMatch(s, selector)),
-        ),
-      );
-    }
+    });
+
+    await this.operationLock;
   }
 }


### PR DESCRIPTION
- Add mutex lock to ConnectionsRepoLocalStorage.set() to prevent concurrent write operations from overwriting each other
- Fix addressType inconsistency in BitcoinSigner.connect() by using this.addressType instead of res.btcAddressType