### PR TITLE
feat(core): add `CellAny`

### DIFF
--- a/.changeset/salty-apples-check.md
+++ b/.changeset/salty-apples-check.md
@@ -1,0 +1,9 @@
+---
+"@ckb-ccc/core": minor
+"@ckb-ccc/ssri": patch
+---
+
+feat(core): add `CellAny`
+
+It's definitely a mistake to name `CellOnChain` `Cell`, but there is nothing we can do with that right now. To avoid more duplicate code, `CellAny` was added to represent a cell that's on-chain or off-chain.
+  

--- a/packages/core/src/client/jsonRpc/transformers.ts
+++ b/packages/core/src/client/jsonRpc/transformers.ts
@@ -124,7 +124,12 @@ export class JsonRpcTransformers {
       since: cellInput.since,
     });
   }
-  static cellOutputFrom(cellOutput: CellOutputLike): JsonRpcCellOutput {
+  static cellOutputFrom(
+    cellOutputLike: CellOutputLike,
+    outputData?: HexLike | null,
+  ): JsonRpcCellOutput {
+    const cellOutput = CellOutput.from(cellOutputLike, outputData);
+
     return {
       capacity: numToHex(cellOutput.capacity),
       lock: JsonRpcTransformers.scriptFrom(cellOutput.lock),

--- a/packages/ssri/src/executor.ts
+++ b/packages/ssri/src/executor.ts
@@ -4,13 +4,13 @@ import { getMethodPath } from "./utils.js";
 
 export type ContextTransaction = {
   script?: ccc.ScriptLike | null;
-  cell?: Omit<ccc.CellLike, "outPoint"> | null;
+  cell?: ccc.CellAnyLike | null;
   tx: ccc.TransactionLike;
 };
 
 export type ContextCell = {
   script?: ccc.ScriptLike | null;
-  cell: Omit<ccc.CellLike, "outPoint">;
+  cell: ccc.CellAnyLike;
   tx?: undefined | null;
 };
 
@@ -175,14 +175,17 @@ export class ExecutorJsonRpc extends Executor {
         ];
       }
       if (context?.cell) {
+        const cell = ccc.CellAny.from(context.cell);
+
         return [
           "run_script_level_cell",
           [
             {
               cell_output: cccA.JsonRpcTransformers.cellOutputFrom(
-                ccc.CellOutput.from(context.cell.cellOutput),
+                cell.cellOutput,
+                cell.outputData,
               ),
-              hex_data: ccc.hexFrom(context.cell.outputData),
+              hex_data: ccc.hexFrom(cell.outputData),
             },
           ],
         ];


### PR DESCRIPTION
It's definitely a mistake to name `CellOnChain` `Cell`, but there is nothing we can do with that right now. To avoid more duplicate code, `CellAny` was added to represent a cell that's on-chain or off-chain.