### PR TITLE
feat(core): default `Signer.prepareTransaction`

### DIFF
--- a/.changeset/old-eagles-bake.md
+++ b/.changeset/old-eagles-bake.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": patch
+---
+
+feat(core): default `Signer.prepareTransaction`
+  

--- a/packages/core/src/signer/signer/index.ts
+++ b/packages/core/src/signer/signer/index.ts
@@ -459,14 +459,23 @@ export abstract class Signer {
   }
 
   /**
-   * prepare a transaction before signing. This method is not implemented and should be overridden by subclasses.
+   * Prepares a transaction before signing.
+   * This method can be overridden by subclasses to perform any necessary steps,
+   * such as adding cell dependencies or witnesses, before the transaction is signed.
+   * The default implementation converts the {@link TransactionLike} object to a {@link Transaction} object
+   * without modification.
    *
-   * @param _ - The transaction to prepare, represented as a TransactionLike object.
-   * @returns A promise that resolves to the prepared Transaction object.
-   * @throws Will throw an error if not implemented.
+   * @remarks
+   * Note that this default implementation does not add any cell dependencies or dummy witnesses.
+   * This may lead to an underestimation of transaction size and fees if used with methods
+   * like `Transaction.completeFee`. Subclasses for signers that are intended to sign
+   * transactions should override this method to perform necessary preparations.
+   *
+   * @param tx - The transaction to prepare.
+   * @returns A promise that resolves to the prepared {@link Transaction} object.
    */
-  prepareTransaction(_: TransactionLike): Promise<Transaction> {
-    throw Error("Signer.prepareTransaction not implemented");
+  async prepareTransaction(tx: TransactionLike): Promise<Transaction> {
+    return Transaction.from(tx);
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)

This should allow invoking `Transaction.complete*` methods with readonly signers. Though it might cause the wrong fee rate, this should not be a problem since the Signer still can't sign & send the transaction.