### PR TITLE
feat(core): add `Owner` for explicit resource ownership

### DIFF
--- a/.changeset/clear-areas-shave.md
+++ b/.changeset/clear-areas-shave.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": minor
+---
+
+feat(core): add `Owner.map` and `OwnerAggregated`
+  

--- a/.changeset/cold-schools-occur.md
+++ b/.changeset/cold-schools-occur.md
@@ -1,6 +1,5 @@
 ---
-"@ckb-ccc/connector-react": patch
+"@ckb-ccc/connector-react": minor
 ---
 
-fix(connector-react): manage ownership transferred through setClient while keeping defaultClient and clientOptions borrowed
-  
+feat(connector-react): control Web Component Client requests in the Provider, manage ownership transferred through setClient, and add useBorrowedOrOwned for an internally owned fallback to an optional borrowed value

--- a/.changeset/cold-schools-occur.md
+++ b/.changeset/cold-schools-occur.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/connector-react": patch
+---
+
+fix(connector-react): manage ownership transferred through setClient while keeping defaultClient and clientOptions borrowed
+  

--- a/.changeset/cozy-lions-warn.md
+++ b/.changeset/cozy-lions-warn.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": minor
+---
+
+feat(core): add ownership-aware `open` APIs for JSON-RPC clients and transports
+  

--- a/.changeset/large-cloths-dress.md
+++ b/.changeset/large-cloths-dress.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/connector": patch
+---
+
+fix(connector): dispose the internally created default Client with the custom element lifecycle
+  

--- a/.changeset/large-cloths-dress.md
+++ b/.changeset/large-cloths-dress.md
@@ -1,6 +1,5 @@
 ---
-"@ckb-ccc/connector": patch
+"@ckb-ccc/connector": major
 ---
 
-fix(connector): dispose the internally created default Client with the custom element lifecycle
-  
+refactor(connector): require a controlled borrowed Client, emit bubbling select-client requests for network and fee-rate changes, and remove Client ownership from the Web Component lifecycle

--- a/.changeset/late-tires-hide.md
+++ b/.changeset/late-tires-hide.md
@@ -1,8 +1,7 @@
 ---
 "@ckb-ccc/core": minor
-"@ckb-ccc/connector": patch
-"@ckb-ccc/connector-react": patch
 ---
 
-feat(core): `Transport/Requestor/Client.close`
-  
+feat(core): improve JSON-RPC transport types and cleanup
+
+Clear HTTP/WebSocket request timers and pending state.

--- a/.changeset/legal-peas-kick.md
+++ b/.changeset/legal-peas-kick.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": minor
+---
+
+feat(core): add `OwnerRefCount` for shared resource ownership
+  

--- a/.changeset/rare-maps-carry.md
+++ b/.changeset/rare-maps-carry.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/ssri": minor
+---
+
+feat(ssri): add ownership-aware `new` and `open` APIs for JSON-RPC executors
+  

--- a/.changeset/shaggy-needles-stare.md
+++ b/.changeset/shaggy-needles-stare.md
@@ -1,0 +1,6 @@
+---
+"@ckb-ccc/core": minor
+---
+
+feat(core): add `Owner` and `OwnerUnique` for explicit resource ownership
+  

--- a/packages/app/src/app/modules/ssri-module.tsx
+++ b/packages/app/src/app/modules/ssri-module.tsx
@@ -68,11 +68,15 @@ async function callSsri(
   if (!scriptCell) throw new Error("SSRI contract cell not found");
   const args = splitLines(argsText).map((value) => ccc.hexFrom(value));
   const context = parseContext(contextLevel, contextText);
-  const executor = new ssri.ExecutorJsonRpc(executorUrl);
-  const contract = new ssri.Trait(scriptCell.outPoint, executor);
-  return contract
-    .assertExecutor()
-    .runScript(contract.code, method, args, context);
+  const executorOwner = ssri.ExecutorJsonRpc.open({ urls: [executorUrl] });
+  try {
+    const contract = new ssri.Trait(scriptCell.outPoint, executorOwner.value);
+    return await contract
+      .assertExecutor()
+      .runScript(contract.code, method, args, context);
+  } finally {
+    await executorOwner.dispose();
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/app/src/app/page.tsx
+++ b/packages/app/src/app/page.tsx
@@ -194,8 +194,8 @@ export default function Home() {
     setTelemetry(undefined);
     setClient(
       nextIsMainnet
-        ? new ccc.ClientPublicMainnet()
-        : new ccc.ClientPublicTestnet(),
+        ? ccc.ClientPublicMainnet.open()
+        : ccc.ClientPublicTestnet.open(),
     );
   };
 

--- a/packages/app/src/app/provider.tsx
+++ b/packages/app/src/app/provider.tsx
@@ -1,19 +1,29 @@
 "use client";
 
 import { ccc } from "@ckb-ccc/connector-react";
+import { useEffect, useState, type ReactNode } from "react";
 
-const clientOptions = [
-  {
-    name: "CKB Testnet",
-    client: new ccc.ClientPublicTestnet(),
-  },
-  {
-    name: "CKB Mainnet",
-    client: new ccc.ClientPublicMainnet(),
-  },
-];
+export function AppProvider({ children }: { children: ReactNode }) {
+  const [clientOptions, setClientOptions] =
+    useState<{ name: string; client: ccc.Client }[]>();
 
-export function AppProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const owner = ccc.OwnerAggregated.from([
+      ccc.ClientPublicTestnet.open(),
+      ccc.ClientPublicMainnet.open(),
+    ] as const);
+    const [testnet, mainnet] = owner.value;
+    // The clients must be opened after commit to avoid leaking aborted renders.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setClientOptions([
+      { name: "CKB Testnet", client: testnet },
+      { name: "CKB Mainnet", client: mainnet },
+    ]);
+    return () => void owner.dispose().catch(() => {});
+  }, []);
+
+  if (!clientOptions) return null;
+
   return (
     <ccc.Provider
       name="CCC Precision Toolkit"

--- a/packages/connector-react/src/components/index.ts
+++ b/packages/connector-react/src/components/index.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { ccc } from "@ckb-ccc/connector";
-import { createComponent } from "@lit/react";
+import { EventName, createComponent } from "@lit/react";
 import * as React from "react";
 
 export const Connector = createComponent({
@@ -9,7 +9,11 @@ export const Connector = createComponent({
   elementClass: ccc.WebComponentConnector,
   react: React,
   events: {
-    onWillUpdate: "willUpdate",
-    onClose: "close",
+    onWillUpdate: ccc.ConnectorWillUpdateEvent
+      .eventName as EventName<ccc.ConnectorWillUpdateEvent>,
+    onClose: ccc.ConnectorCloseEvent
+      .eventName as EventName<ccc.ConnectorCloseEvent>,
+    onSelectClient: ccc.SelectClientEvent
+      .eventName as EventName<ccc.SelectClientEvent>,
   },
 });

--- a/packages/connector-react/src/hooks/index.ts
+++ b/packages/connector-react/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from "./useBorrowedOrOwned.js";
 export * from "./useCcc.js";
 export * from "./useSigner.js";

--- a/packages/connector-react/src/hooks/useBorrowedOrOwned.ts
+++ b/packages/connector-react/src/hooks/useBorrowedOrOwned.ts
@@ -1,0 +1,21 @@
+import { ccc } from "@ckb-ccc/connector";
+import { useEffect, useState } from "react";
+
+/**
+ * Opens and owns a fallback value after the component commits, while returning
+ * a borrowed value whenever one is provided.
+ */
+export function useBorrowedOrOwned<T>(
+  borrowed: T | undefined,
+  open: () => ccc.Owner<T>,
+): T | undefined {
+  const [owned, setOwned] = useState<T>();
+
+  useEffect(() => {
+    const owner = open();
+    setOwned(owner.value);
+    return () => void owner.dispose().catch(() => {});
+  }, [open]);
+
+  return borrowed ?? owned;
+}

--- a/packages/connector-react/src/hooks/useCcc.tsx
+++ b/packages/connector-react/src/hooks/useCcc.tsx
@@ -19,10 +19,6 @@ const CCC_CONTEXT = createContext<
       open: () => unknown;
       close: () => unknown;
       disconnect: () => unknown;
-      /**
-       * Sets the active client and transfers its ownership to the connector.
-       * The connector may close the client when it is replaced or disconnected.
-       */
       setClient: (client: ccc.Client) => unknown;
       client: ccc.Client;
       wallet?: ccc.Wallet;
@@ -80,9 +76,7 @@ export function Provider({
     wallet: ccc.Wallet,
   ) => Promise<boolean>;
   signersController?: ccc.SignersController;
-  /** Transferred to the connector, which may subsequently close it. */
   defaultClient?: ccc.Client;
-  /** Selected clients are transferred to the connector and may be closed. */
   clientOptions?: { icon?: string; client: ccc.Client; name: string }[];
   preferredNetworks?: ccc.NetworkPreference[];
 }) {

--- a/packages/connector-react/src/hooks/useCcc.tsx
+++ b/packages/connector-react/src/hooks/useCcc.tsx
@@ -13,13 +13,26 @@ import React, {
 } from "react";
 import { Connector } from "../components/index.js";
 
+type ClientInput = ccc.Client | ccc.Owner<ccc.Client>;
+
+function isOwner(resource: ClientInput): resource is ccc.Owner<ccc.Client> {
+  return "dispose" in resource && typeof resource.dispose === "function";
+}
+
+interface SetClient {
+  (owner: ccc.Owner<ccc.Client>): void;
+  /** @deprecated Pass an Owner<Client> so the Provider can manage its lifecycle. */
+  (client: ccc.Client): void;
+  (resource: ccc.Client | ccc.Owner<ccc.Client>): void;
+}
+
 const CCC_CONTEXT = createContext<
   | {
       isOpen: boolean;
       open: () => unknown;
       close: () => unknown;
       disconnect: () => unknown;
-      setClient: (client: ccc.Client) => unknown;
+      setClient: SetClient;
       client: ccc.Client;
       wallet?: ccc.Wallet;
       signerInfo?: ccc.SignerInfo;
@@ -86,11 +99,41 @@ export function Provider({
   const defaultSignersController = useRef<
     SignersControllerWithFilter | undefined
   >(undefined);
+  const replacementOwner = useRef<ccc.Owner<ccc.Client> | undefined>(undefined);
+  const providedClient = defaultClient ?? clientOptions?.[0]?.client;
+  const [fallbackClient, setFallbackClient] = useState<ccc.Client>();
 
-  const [initialClient] = useState(
-    () => defaultClient ?? new ccc.ClientPublicTestnet(),
-  );
+  useEffect(() => {
+    if (providedClient) return;
+
+    const owner = ccc.ClientPublicTestnet.open();
+    setFallbackClient(owner.value);
+    return () => void owner.dispose().catch(() => {});
+  }, [providedClient]);
+
+  const initialClient = providedClient ?? fallbackClient;
   const client = ref?.client ?? initialClient;
+  const setClient = useCallback(
+    (resource: ClientInput) => {
+      const owner = isOwner(resource)
+        ? resource.map((value) => value)
+        : new ccc.OwnerUnique(resource, () => {});
+      const previous = replacementOwner.current;
+      replacementOwner.current = owner;
+      if (previous) void previous.dispose().catch(() => {});
+      ref?.setClient(owner.value);
+    },
+    [ref],
+  );
+
+  useEffect(
+    () => () => {
+      void replacementOwner.current?.dispose().catch(() => {});
+      replacementOwner.current = undefined;
+    },
+    [],
+  );
+
   const open = useCallback(() => {
     setIsOpen(true);
     ref?.requestUpdate();
@@ -103,14 +146,6 @@ export function Provider({
     () => ref?.disconnect.bind(ref) ?? (() => {}),
     [ref, ref?.disconnect],
   );
-  const setClient = useMemo(
-    () => ref?.setClient.bind(ref) ?? (() => {}),
-    [ref, ref?.setClient],
-  );
-
-  useEffect(() => {
-    setClient(initialClient);
-  }, [initialClient, setClient]);
   useEffect(() => {
     if (!defaultSignersController.current) {
       defaultSignersController.current = new SignersControllerWithFilter(
@@ -120,6 +155,8 @@ export function Provider({
       defaultSignersController.current.filter = signerFilter;
     }
   }, [signerFilter]);
+
+  if (!client || !initialClient) return null;
 
   return (
     <CCC_CONTEXT.Provider
@@ -136,6 +173,7 @@ export function Provider({
       }}
     >
       <Connector
+        client={initialClient}
         hideMark={hideMark}
         name={name}
         icon={icon}

--- a/packages/connector-react/src/hooks/useCcc.tsx
+++ b/packages/connector-react/src/hooks/useCcc.tsx
@@ -12,6 +12,11 @@ import React, {
   useState,
 } from "react";
 import { Connector } from "../components/index.js";
+import { useBorrowedOrOwned } from "./useBorrowedOrOwned.js";
+
+function openDefaultClient(): ccc.Owner<ccc.Client> {
+  return ccc.ClientPublicTestnet.open();
+}
 
 type ClientInput = ccc.Client | ccc.Owner<ccc.Client>;
 
@@ -42,7 +47,7 @@ const CCC_CONTEXT = createContext<
 
 class SignersControllerWithFilter extends ccc.SignersController {
   constructor(
-    public filter?: (
+    public readonly filter?: (
       signerInfo: ccc.SignerInfo,
       wallet: ccc.Wallet,
     ) => Promise<boolean>,
@@ -96,40 +101,40 @@ export function Provider({
   const [ref, setRef] = useState<ccc.WebComponentConnector | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [_, setFlag] = useState(0);
-  const defaultSignersController = useRef<
-    SignersControllerWithFilter | undefined
-  >(undefined);
-  const replacementOwner = useRef<ccc.Owner<ccc.Client> | undefined>(undefined);
-  const providedClient = defaultClient ?? clientOptions?.[0]?.client;
-  const [fallbackClient, setFallbackClient] = useState<ccc.Client>();
-
-  useEffect(() => {
-    if (providedClient) return;
-
-    const owner = ccc.ClientPublicTestnet.open();
-    setFallbackClient(owner.value);
-    return () => void owner.dispose().catch(() => {});
-  }, [providedClient]);
-
-  const initialClient = providedClient ?? fallbackClient;
-  const client = ref?.client ?? initialClient;
-  const setClient = useCallback(
-    (resource: ClientInput) => {
-      const owner = isOwner(resource)
-        ? resource.map((value) => value)
-        : new ccc.OwnerUnique(resource, () => {});
-      const previous = replacementOwner.current;
-      replacementOwner.current = owner;
-      if (previous) void previous.dispose().catch(() => {});
-      ref?.setClient(owner.value);
-    },
-    [ref],
+  const defaultSignersController = useMemo(
+    () => new SignersControllerWithFilter(signerFilter),
+    [signerFilter],
   );
+
+  const initialClient = useBorrowedOrOwned(
+    defaultClient ?? clientOptions?.[0]?.client,
+    openDefaultClient,
+  );
+  const [selectedClient, setSelectedClient] = useState<ccc.Client>();
+  const adoptedClientOwner = useRef<ccc.Owner<ccc.Client> | undefined>(
+    undefined,
+  );
+  const client = selectedClient ?? initialClient;
+
+  const setClient = useCallback((resource: ClientInput) => {
+    const owner = isOwner(resource)
+      ? resource.map((value) => value)
+      : new ccc.OwnerUnique(resource, () => {});
+
+    const previous = adoptedClientOwner.current;
+    adoptedClientOwner.current = owner;
+    if (previous) void previous.dispose().catch(() => {});
+    setSelectedClient(owner.value);
+  }, []);
+
+  const onSelectClient = useCallback((event: ccc.SelectClientEvent) => {
+    setSelectedClient(event.client);
+  }, []);
 
   useEffect(
     () => () => {
-      void replacementOwner.current?.dispose().catch(() => {});
-      replacementOwner.current = undefined;
+      void adoptedClientOwner.current?.dispose().catch(() => {});
+      adoptedClientOwner.current = undefined;
     },
     [],
   );
@@ -146,17 +151,7 @@ export function Provider({
     () => ref?.disconnect.bind(ref) ?? (() => {}),
     [ref, ref?.disconnect],
   );
-  useEffect(() => {
-    if (!defaultSignersController.current) {
-      defaultSignersController.current = new SignersControllerWithFilter(
-        signerFilter,
-      );
-    } else {
-      defaultSignersController.current.filter = signerFilter;
-    }
-  }, [signerFilter]);
-
-  if (!client || !initialClient) return null;
+  if (!client) return null;
 
   return (
     <CCC_CONTEXT.Provider
@@ -173,13 +168,11 @@ export function Provider({
       }}
     >
       <Connector
-        client={initialClient}
+        client={client}
         hideMark={hideMark}
         name={name}
         icon={icon}
-        signersController={
-          signersController ?? defaultSignersController.current
-        }
+        signersController={signersController ?? defaultSignersController}
         ref={setRef}
         onWillUpdate={() => setFlag((f) => f + 1)}
         onClose={close}
@@ -208,6 +201,7 @@ export function Provider({
             ...connectorProps?.style,
           },
         }}
+        onSelectClient={onSelectClient}
       />
       {children}
     </CCC_CONTEXT.Provider>

--- a/packages/connector-react/src/hooks/useCcc.tsx
+++ b/packages/connector-react/src/hooks/useCcc.tsx
@@ -16,7 +16,7 @@ import { Connector } from "../components/index.js";
 type ClientInput = ccc.Client | ccc.Owner<ccc.Client>;
 
 function isOwner(resource: ClientInput): resource is ccc.Owner<ccc.Client> {
-  return "dispose" in resource && typeof resource.dispose === "function";
+  return ccc.Owner.is(resource);
 }
 
 interface SetClient {

--- a/packages/connector/src/barrel.ts
+++ b/packages/connector/src/barrel.ts
@@ -1,5 +1,6 @@
 export * from "@ckb-ccc/ccc/barrel";
 export * from "./connector/index.js";
+export * from "./events/external.js";
 
 import "./components/index.js";
 import "./scenes/index.js";

--- a/packages/connector/src/components/dialog.ts
+++ b/packages/connector/src/components/dialog.ts
@@ -2,7 +2,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { CLOSE_SVG } from "../assets/close.svg.js";
 import { LEFT_SVG } from "../assets/left.svg.js";
-import { CloseEvent } from "../events/index.js";
+import { CloseRequestEvent } from "../events/internal.js";
 
 @customElement("ccc-dialog")
 export class Dialog extends LitElement {
@@ -28,7 +28,7 @@ export class Dialog extends LitElement {
         <span
           class="close active"
           @click=${() => {
-            this.dispatchEvent(new CloseEvent());
+            this.dispatchEvent(new CloseRequestEvent());
           }}
         >
           ${CLOSE_SVG}

--- a/packages/connector/src/connector/index.ts
+++ b/packages/connector/src/connector/index.ts
@@ -27,20 +27,26 @@ export class WebComponentConnector extends LitElement {
   @state()
   public clientOptions?: { icon?: string; client: ccc.Client; name: string }[];
 
-  private _client = new ClientWithFeeRate(new ccc.ClientPublicTestnet());
+  private _client?: ccc.Owner<ClientWithFeeRate> = this.openDefaultClient();
 
-  // The connector owns and may switch the active client internally, so it is
-  // state rather than an externally controlled property.
+  // The connector tracks the active Client through an Owner. Externally
+  // supplied Clients are wrapped with a no-op disposer and remain borrowed.
   @state()
   public get client(): ccc.Client {
-    return this._client;
+    if (!this._client) {
+      throw new Error("Connector is not connected");
+    }
+    return this._client.value;
   }
   public set client(client: ccc.Client) {
-    if (client === this._client || client === this._client[ccc.Proxy.inner]) {
+    const current = this._client?.value;
+    if (client === current || client === current?.[ccc.Proxy.inner]) {
       return;
     }
 
-    this._client = new ClientWithFeeRate(client);
+    this.replaceClient(
+      new ccc.OwnerUnique(new ClientWithFeeRate(client), () => {}),
+    );
   }
 
   public setClient(client: ccc.Client) {
@@ -91,14 +97,31 @@ export class WebComponentConnector extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    if (!this._client) {
+      this._client = this.openDefaultClient();
+      this.requestUpdate("client");
+    }
     this.loadConnection();
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    this.replaceClient();
     this.signerUpdateId += 1;
     this.unregisterSignerReplacer?.();
     this.unregisterSignerReplacer = undefined;
+  }
+
+  private openDefaultClient(): ccc.Owner<ClientWithFeeRate> {
+    return ccc.ClientPublicTestnet.open().map(
+      (client) => new ClientWithFeeRate(client),
+    );
+  }
+
+  private replaceClient(client?: ccc.Owner<ClientWithFeeRate>): void {
+    const previous = this._client;
+    this._client = client;
+    void previous?.dispose().catch(() => {});
   }
 
   willUpdate(changedProperties: PropertyValues): void {
@@ -166,6 +189,9 @@ export class WebComponentConnector extends LitElement {
     createRef();
 
   render() {
+    const client = this._client?.value;
+    if (!client) return;
+
     return html`<div
       class="background"
       @click=${(event: Event) => {
@@ -187,11 +213,11 @@ export class WebComponentConnector extends LitElement {
                   ?hideMark=${this.hideMark}
                   .wallet=${this.wallet}
                   .signer=${this.signer.signer}
-                  .feeRate=${this._client.feeRate}
+                  .feeRate=${client.feeRate}
                   .clientOptions=${this.clientOptions}
                   @disconnect=${() => this.disconnect()}
                   @fee-rate-selected=${(event: FeeRateSelectedEvent) => {
-                    this._client.feeRate = event.feeRate;
+                    client.feeRate = event.feeRate;
                     this.requestUpdate();
                   }}
                   @select-client=${(e: SelectClientEvent) =>

--- a/packages/connector/src/connector/index.ts
+++ b/packages/connector/src/connector/index.ts
@@ -31,6 +31,8 @@ export class WebComponentConnector extends LitElement {
 
   // The connector tracks the active Client through an Owner. Externally
   // supplied Clients are wrapped with a no-op disposer and remain borrowed.
+  // TODO(next major): Return `ccc.Client | undefined` from `client` instead of
+  // throwing when the connector is disconnected.
   @state()
   public get client(): ccc.Client {
     if (!this._client) {

--- a/packages/connector/src/connector/index.ts
+++ b/packages/connector/src/connector/index.ts
@@ -40,15 +40,9 @@ export class WebComponentConnector extends LitElement {
       return;
     }
 
-    const previous = this.client;
     this._client = new ClientWithFeeRate(client);
-    this.closeClient(previous);
   }
 
-  /**
-   * Sets the active client and transfers its ownership to the connector.
-   * The connector may close the client when it is replaced or disconnected.
-   */
   public setClient(client: ccc.Client) {
     this.client = client;
   }
@@ -105,20 +99,6 @@ export class WebComponentConnector extends LitElement {
     this.signerUpdateId += 1;
     this.unregisterSignerReplacer?.();
     this.unregisterSignerReplacer = undefined;
-    this.closeClient(this.client);
-  }
-
-  private closeClient(client: ccc.Client): void {
-    void client.close().catch((error: unknown) => {
-      this.dispatchEvent(
-        new ErrorEvent("error", {
-          bubbles: true,
-          composed: true,
-          error,
-          message: error instanceof Error ? error.message : String(error),
-        }),
-      );
-    });
   }
 
   willUpdate(changedProperties: PropertyValues): void {

--- a/packages/connector/src/connector/index.ts
+++ b/packages/connector/src/connector/index.ts
@@ -3,13 +3,25 @@ import { LitElement, PropertyValues, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 import {
-  CloseEvent,
+  ConnectorCloseEvent,
+  ConnectorWillUpdateEvent,
+  SelectClientEvent,
+} from "../events/external.js";
+import {
+  CloseRequestEvent,
   ConnectedEvent,
   FeeRateSelectedEvent,
-  SelectClientEvent,
-} from "../events/index.js";
+} from "../events/internal.js";
 import { SignersController } from "../signers/index.js";
 import { ClientWithFeeRate } from "./client.js";
+
+const SIGNER_REFRESH_PROPERTIES = [
+  "name",
+  "icon",
+  "client",
+  "signersController",
+  "preferredNetworks",
+] as const satisfies readonly (keyof WebComponentConnector)[];
 
 @customElement("ccc-connector")
 export class WebComponentConnector extends LitElement {
@@ -22,38 +34,14 @@ export class WebComponentConnector extends LitElement {
   /** @deprecated This compatibility property is ignored. */
   @property()
   public preferredNetworks?: ccc.NetworkPreference[];
-  @property()
-  public signersController?: ccc.SignersController;
+  @property({ attribute: false })
+  public signersController = new ccc.SignersController();
   @state()
   public clientOptions?: { icon?: string; client: ccc.Client; name: string }[];
 
-  private _client?: ccc.Owner<ClientWithFeeRate> = this.openDefaultClient();
-
-  // The connector tracks the active Client through an Owner. Externally
-  // supplied Clients are wrapped with a no-op disposer and remain borrowed.
-  // TODO(next major): Return `ccc.Client | undefined` from `client` instead of
-  // throwing when the connector is disconnected.
-  @state()
-  public get client(): ccc.Client {
-    if (!this._client) {
-      throw new Error("Connector is not connected");
-    }
-    return this._client.value;
-  }
-  public set client(client: ccc.Client) {
-    const current = this._client?.value;
-    if (client === current || client === current?.[ccc.Proxy.inner]) {
-      return;
-    }
-
-    this.replaceClient(
-      new ccc.OwnerUnique(new ClientWithFeeRate(client), () => {}),
-    );
-  }
-
-  public setClient(client: ccc.Client) {
-    this.client = client;
-  }
+  /** A required borrowed Client supplied by the integration layer. */
+  @property({ attribute: false })
+  public client!: ccc.Client;
 
   private signersControllerInner = new SignersController(this);
 
@@ -99,40 +87,21 @@ export class WebComponentConnector extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    if (!this._client) {
-      this._client = this.openDefaultClient();
-      this.requestUpdate("client");
-    }
     this.loadConnection();
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.replaceClient();
     this.signerUpdateId += 1;
     this.unregisterSignerReplacer?.();
     this.unregisterSignerReplacer = undefined;
   }
 
-  private openDefaultClient(): ccc.Owner<ClientWithFeeRate> {
-    return ccc.ClientPublicTestnet.open().map(
-      (client) => new ClientWithFeeRate(client),
-    );
-  }
-
-  private replaceClient(client?: ccc.Owner<ClientWithFeeRate>): void {
-    const previous = this._client;
-    this._client = client;
-    void previous?.dispose().catch(() => {});
-  }
-
   willUpdate(changedProperties: PropertyValues): void {
     if (
-      changedProperties.has("name") ||
-      changedProperties.has("icon") ||
-      changedProperties.has("client") ||
-      changedProperties.has("signerFilter") ||
-      changedProperties.has("preferredNetworks")
+      SIGNER_REFRESH_PROPERTIES.some((property) =>
+        changedProperties.has(property),
+      )
     ) {
       void this.signersControllerInner.refresh();
     }
@@ -143,7 +112,20 @@ export class WebComponentConnector extends LitElement {
       this.refreshSigner();
     }
 
-    this.dispatchEvent(new Event("willUpdate"));
+    this.dispatchEvent(new ConnectorWillUpdateEvent());
+  }
+
+  private requestClientWithFeeRate(event: FeeRateSelectedEvent): void {
+    event.stopPropagation();
+
+    const current = this.client;
+    const client =
+      current instanceof ClientWithFeeRate
+        ? current
+        : new ClientWithFeeRate(current);
+    client.feeRate = event.feeRate;
+    this.requestUpdate();
+    this.dispatchEvent(new SelectClientEvent(client));
   }
 
   refreshSigner() {
@@ -191,8 +173,9 @@ export class WebComponentConnector extends LitElement {
     createRef();
 
   render() {
-    const client = this._client?.value;
-    if (!client) return;
+    const client = this.client;
+    const feeRate =
+      client instanceof ClientWithFeeRate ? client.feeRate : undefined;
 
     return html`<div
       class="background"
@@ -201,7 +184,7 @@ export class WebComponentConnector extends LitElement {
           this.onClose();
         }
       }}
-      @close=${(event: CloseEvent) => {
+      @close=${(event: CloseRequestEvent) => {
         event.stopPropagation();
         this.onClose(event.callback);
       }}
@@ -215,15 +198,11 @@ export class WebComponentConnector extends LitElement {
                   ?hideMark=${this.hideMark}
                   .wallet=${this.wallet}
                   .signer=${this.signer.signer}
-                  .feeRate=${client.feeRate}
+                  .feeRate=${feeRate}
                   .clientOptions=${this.clientOptions}
                   @disconnect=${() => this.disconnect()}
-                  @fee-rate-selected=${(event: FeeRateSelectedEvent) => {
-                    client.feeRate = event.feeRate;
-                    this.requestUpdate();
-                  }}
-                  @select-client=${(e: SelectClientEvent) =>
-                    this.setClient(e.client)}
+                  @fee-rate-selected=${(event: FeeRateSelectedEvent) =>
+                    this.requestClientWithFeeRate(event)}
                   ${ref(this.bodyRef)}
                 ></ccc-connected-scene>
               `
@@ -250,7 +229,7 @@ export class WebComponentConnector extends LitElement {
     }
 
     setTimeout(() => {
-      this.dispatchEvent(new CloseEvent());
+      this.dispatchEvent(new ConnectorCloseEvent());
       this.bodyRef.value?.onClose?.();
       onClosed?.();
     }, 150);

--- a/packages/connector/src/events/external.ts
+++ b/packages/connector/src/events/external.ts
@@ -1,0 +1,31 @@
+import { ccc } from "@ckb-ccc/ccc";
+
+export class ConnectorWillUpdateEvent extends Event {
+  static readonly eventName = "willUpdate";
+
+  constructor() {
+    super(ConnectorWillUpdateEvent.eventName);
+  }
+}
+
+export class ConnectorCloseEvent extends Event {
+  static readonly eventName = "close";
+
+  constructor() {
+    super(ConnectorCloseEvent.eventName, { bubbles: true, composed: true });
+  }
+}
+
+export class SelectClientEvent extends Event {
+  static readonly eventName = "select-client";
+
+  constructor(public readonly client: ccc.Client) {
+    super(SelectClientEvent.eventName, { bubbles: true, composed: true });
+  }
+}
+
+export interface ConnectorEventMap {
+  [ConnectorWillUpdateEvent.eventName]: ConnectorWillUpdateEvent;
+  [ConnectorCloseEvent.eventName]: ConnectorCloseEvent;
+  [SelectClientEvent.eventName]: SelectClientEvent;
+}

--- a/packages/connector/src/events/internal.ts
+++ b/packages/connector/src/events/internal.ts
@@ -1,11 +1,5 @@
 import { ccc } from "@ckb-ccc/ccc";
 
-export class SelectClientEvent extends Event {
-  constructor(public client: ccc.Client) {
-    super("select-client");
-  }
-}
-
 export class FeeRateSelectedEvent extends Event {
   constructor(public readonly feeRate?: ccc.Num) {
     super("fee-rate-selected", { bubbles: true, composed: true });
@@ -21,8 +15,8 @@ export class ConnectedEvent extends Event {
   }
 }
 
-export class CloseEvent extends Event {
-  constructor(public callback?: () => void) {
+export class CloseRequestEvent extends Event {
+  constructor(public readonly callback?: () => void) {
     super("close", { bubbles: true, composed: true });
   }
 }

--- a/packages/connector/src/scenes/connected.ts
+++ b/packages/connector/src/scenes/connected.ts
@@ -7,7 +7,7 @@ import { DISCONNECT_SVG } from "../assets/diconnect.svg.js";
 import { FEE_SVG } from "../assets/fee.svg.js";
 import { SWAP_SVG } from "../assets/swap.svg.js";
 import { USER_SVG } from "../assets/user.svg.js";
-import { SelectClientEvent } from "../events/index.js";
+import { SelectClientEvent } from "../events/external.js";
 import { signerTypeToIcon } from "./selecting/signers.js";
 
 export function formatString(

--- a/packages/connector/src/scenes/fee-rate.ts
+++ b/packages/connector/src/scenes/fee-rate.ts
@@ -1,7 +1,7 @@
 import { ccc } from "@ckb-ccc/ccc";
 import { css, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { FeeRateSelectedEvent } from "../events/index.js";
+import { FeeRateSelectedEvent } from "../events/internal.js";
 
 type FeeRateOption = {
   description: string;

--- a/packages/connector/src/scenes/selecting/index.ts
+++ b/packages/connector/src/scenes/selecting/index.ts
@@ -1,7 +1,7 @@
 import { ccc } from "@ckb-ccc/ccc";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { CloseEvent, ConnectedEvent } from "../../events/index.js";
+import { CloseRequestEvent, ConnectedEvent } from "../../events/internal.js";
 import { generateConnectingScene } from "./connecting.js";
 import { generateSignersScene } from "./signers.js";
 import { generateWalletsScene } from "./wallets.js";
@@ -106,7 +106,7 @@ export class SelectingScene extends LitElement {
       }
 
       this.dispatchEvent(
-        new CloseEvent(() => {
+        new CloseRequestEvent(() => {
           this.dispatchEvent(new ConnectedEvent(wallet.name, signerInfo.name));
         }),
       );

--- a/packages/connector/src/signers/index.ts
+++ b/packages/connector/src/signers/index.ts
@@ -3,26 +3,17 @@ import { ReactiveControllerHost } from "lit";
 
 export class SignersController {
   public wallets: ccc.WalletWithSigners[] = [];
-  private readonly defaultController = new ccc.SignersController();
   private refreshId = 0;
   private refreshTimer?: ReturnType<typeof setTimeout>;
-
-  get controller() {
-    return this.host.signersController ?? this.defaultController;
-  }
 
   constructor(
     private readonly host: ReactiveControllerHost & {
       client: ccc.Client;
-      signerFilter?: (
-        signerInfo: ccc.SignerInfo,
-        wallet: ccc.Wallet,
-      ) => Promise<boolean>;
       preferredNetworks?: ccc.NetworkPreference[];
       name?: string;
       icon?: string;
       refreshSigner: () => void;
-      signersController?: ccc.SignersController;
+      signersController: ccc.SignersController;
     },
   ) {
     host.addController(this);
@@ -30,7 +21,7 @@ export class SignersController {
 
   refresh() {
     const refreshId = ++this.refreshId;
-    return this.controller.refresh(
+    return this.host.signersController.refresh(
       this.host.client,
       (wallets) => {
         if (refreshId !== this.refreshId) {
@@ -49,7 +40,6 @@ export class SignersController {
   }
 
   hostConnected(): void {
-    void this.refresh();
     // Wait for plugins to be loaded
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
@@ -61,6 +51,6 @@ export class SignersController {
     clearTimeout(this.refreshTimer);
     this.refreshTimer = undefined;
     this.refreshId += 1;
-    this.controller.disconnect();
+    this.host.signersController.disconnect();
   }
 }

--- a/packages/core/src/ckb/transaction.test.ts
+++ b/packages/core/src/ckb/transaction.test.ts
@@ -9,7 +9,13 @@ let lock: ccc.Script;
 let type: ccc.Script;
 
 beforeEach(async () => {
-  client = new ccc.ClientPublicTestnet();
+  client = ccc.ClientPublicTestnet.new({
+    transport: {
+      request: async () => {
+        throw new Error("Unexpected request");
+      },
+    },
+  });
   signer = new ccc.SignerCkbPublicKey(
     client,
     "0x026f3255791f578cc5e38783b6f2d87d4709697b797def6bf7b3b9af4120e2bfd9",

--- a/packages/core/src/ckb/transaction.ts
+++ b/packages/core/src/ckb/transaction.ts
@@ -1,11 +1,11 @@
 import { Bytes, BytesLike, bytesFrom } from "../bytes/index.js";
+import type { Client } from "../client/client.js";
 import type { ClientCollectableSearchKeyFilterLike } from "../client/clientTypes.advanced.js";
 import {
   ClientBlockHeader,
   type CellDepInfoLike,
-  type Client,
   type ClientBlockHeaderLike,
-} from "../client/index.js";
+} from "../client/clientTypes.js";
 import { KnownScript } from "../client/knownScript.js";
 import { Codec, Entity, codec } from "../codec/index.js";
 import { Zero, fixedPointFrom } from "../fixedPoint/index.js";

--- a/packages/core/src/client/client.test.ts
+++ b/packages/core/src/client/client.test.ts
@@ -11,7 +11,14 @@ describe("Client", () => {
   let client: ClientPublicTestnet;
 
   beforeEach(() => {
-    client = new ClientPublicTestnet({ cache: new ClientCacheMemory() });
+    client = ClientPublicTestnet.new({
+      cache: new ClientCacheMemory(),
+      transport: {
+        request: async () => {
+          throw new Error("Unexpected request");
+        },
+      },
+    });
   });
 
   afterEach(() => {
@@ -106,7 +113,7 @@ describe("Client", () => {
     async function getError(
       data: string,
     ): Promise<ErrorClientVerification | undefined> {
-      const c = new ClientPublicTestnet({
+      const c = ClientPublicTestnet.new({
         transport: {
           async request({ id }) {
             return {

--- a/packages/core/src/client/client.test.ts
+++ b/packages/core/src/client/client.test.ts
@@ -18,20 +18,6 @@ describe("Client", () => {
     vi.restoreAllMocks();
   });
 
-  it("closes its JSON-RPC transport", async () => {
-    const close = vi.fn();
-    const client = new ClientPublicTestnet({
-      transport: {
-        request: async ({ id }) => ({ jsonrpc: "2.0", id, result: null }),
-        close,
-      },
-    });
-
-    await client.close();
-
-    expect(close).toHaveBeenCalledOnce();
-  });
-
   describe("getCell", () => {
     const outPoint = OutPoint.from({
       txHash: `0x${"0".repeat(64)}`,
@@ -122,7 +108,6 @@ describe("Client", () => {
     ): Promise<ErrorClientVerification | undefined> {
       const c = new ClientPublicTestnet({
         transport: {
-          async close() {},
           async request({ id }) {
             return {
               jsonrpc: "2.0",

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -50,9 +50,6 @@ export abstract class Client {
   abstract get url(): string;
   abstract get addressPrefix(): string;
 
-  /** Releases resources held by the client. */
-  abstract close(): Promise<void>;
-
   /**
    * Get the deployment info for a well-known CKB script.
    * Returns the cell deps and type script info needed to use the script.

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -75,7 +75,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    *
    * // Get xUDT script deployment info
    * const xudtInfo = await client.getKnownScript(ccc.KnownScript.XUdt);
@@ -114,7 +116,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const feeRate = await client.getFeeRate();
    * console.log(`Current fee rate: ${feeRate} Shannons/KB`);
    * ```
@@ -145,7 +149,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const tipBlockNumber = await client.getTip();
    * console.log(`Current block height: ${tipBlockNumber}`);
    * ```
@@ -162,7 +168,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const header = await client.getTipHeader();
    * console.log(`Block #${header.number}, hash: ${header.hash}`);
    * ```
@@ -282,7 +290,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const cell = await client.getCell({
    *   txHash: "0xTX_HASH...",
    *   index: 0,
@@ -361,7 +371,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const cell = await client.getCellLive(
    *   { txHash: "0xTX_HASH...", index: 0 },
    *   true,  // include data
@@ -410,7 +422,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const { script: lock } = await ccc.Address.fromString("ckt1q...", client);
    *
    * // Get first page of cells
@@ -475,7 +489,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const { script: lock } = await ccc.Address.fromString("ckt1q...", client);
    *
    * // Find all cells owned by a lock script
@@ -529,7 +545,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const { script: lock } = await ccc.Address.fromString("ckt1q...", client);
    *
    * // Find all cells belonging to this address
@@ -581,7 +599,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * // Find all xUDT cells of a specific token
    * const xudtType = await ccc.Script.fromKnownScript(
    *   client, ccc.KnownScript.XUdt, "0xOWNER_LOCK_HASH...",
@@ -634,7 +654,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const xudtInfo = await client.getKnownScript(ccc.KnownScript.XUdt);
    * const cellDeps = await client.getCellDeps(xudtInfo.cellDeps);
    * // cellDeps can be added to a transaction:
@@ -751,7 +773,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const { script: lock } = await ccc.Address.fromString("ckt1q...", client);
    *
    * // List all transactions related to an address (grouped)
@@ -864,7 +888,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const { script: lock } = await ccc.Address.fromString(
    *   "ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsq...",
    *   client,
@@ -896,7 +922,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const signer = new ccc.SignerCkbPrivateKey(client, "0x...");
    * await signer.connect();
    *
@@ -927,7 +955,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const signer = new ccc.SignerCkbPrivateKey(client, "0x...");
    * await signer.connect();
    *
@@ -971,7 +1001,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * const txResponse = await client.getTransaction("0xTX_HASH...");
    * if (txResponse) {
    *   console.log(`Status: ${txResponse.status}`);
@@ -1044,7 +1076,9 @@ export abstract class Client {
    * ```typescript
    * import { ccc } from "@ckb-ccc/core";
    *
-   * const client = new ccc.ClientPublicTestnet();
+   * const clientOwner = ccc.ClientPublicTestnet.open();
+   * const client = clientOwner.value;
+   * // Call `await clientOwner.dispose()` when the client is no longer needed.
    * // Wait for transaction to be committed (0 confirmations)
    * const tx = await client.waitTransaction("0xTX_HASH...");
    * console.log(`Confirmed in block: ${tx?.blockNumber}`);

--- a/packages/core/src/client/client.ts
+++ b/packages/core/src/client/client.ts
@@ -34,19 +34,33 @@ import {
   ErrorClientWaitTransactionTimeout,
   OutputsValidator,
   ScriptInfo,
+  type ScriptInfoLike,
 } from "./clientTypes.js";
 import { KnownScript } from "./knownScript.js";
+
+export type ClientConfig = {
+  cache?: ClientCache;
+  scripts?: Partial<Record<KnownScript, ScriptInfoLike>>;
+};
 
 /**
  * @public
  */
 export abstract class Client {
   public cache: ClientCache;
+  public readonly scripts: Partial<Record<KnownScript, ScriptInfoLike>>;
 
-  constructor(config?: { cache?: ClientCache }) {
+  constructor(config?: ClientConfig) {
     this.cache = config?.cache ?? new ClientCacheMemory();
+    this.scripts = config?.scripts ?? {};
   }
 
+  /**
+   * The legacy primary URL associated with this Client.
+   *
+   * @deprecated A Client may use multiple endpoints or a Transport without a
+   * URL, so this value does not reliably identify its connection.
+   */
   abstract get url(): string;
   abstract get addressPrefix(): string;
 
@@ -75,7 +89,15 @@ export abstract class Client {
    * );
    * ```
    */
-  abstract getKnownScript(script: KnownScript): Promise<ScriptInfo>;
+  async getKnownScript(script: KnownScript): Promise<ScriptInfo> {
+    const found = this.scripts[script];
+    if (!found) {
+      throw new Error(
+        `No script information was found for ${script} on ${this.addressPrefix}`,
+      );
+    }
+    return ScriptInfo.from(found);
+  }
 
   abstract getFeeRateStatistics(
     blockRange?: NumLike,

--- a/packages/core/src/client/clientKnownScript.test.ts
+++ b/packages/core/src/client/clientKnownScript.test.ts
@@ -2,9 +2,15 @@ import { describe, expect, it } from "vitest";
 import { ClientPublicTestnet } from "./clientPublicTestnet.js";
 import { KnownScript } from "./knownScript.js";
 
+const transport = {
+  request: async () => {
+    throw new Error("Unexpected request");
+  },
+};
+
 describe("Client known scripts", () => {
   it("uses the network's default scripts", async () => {
-    const client = new ClientPublicTestnet();
+    const client = ClientPublicTestnet.new({ transport });
 
     const script = await client.getKnownScript(KnownScript.TypeId);
 
@@ -22,7 +28,7 @@ describe("Client known scripts", () => {
         cellDeps: [],
       },
     };
-    const client = new ClientPublicTestnet({ scripts });
+    const client = ClientPublicTestnet.new({ scripts, transport });
 
     const script = await client.getKnownScript(KnownScript.TypeId);
 

--- a/packages/core/src/client/clientKnownScript.test.ts
+++ b/packages/core/src/client/clientKnownScript.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { ClientPublicTestnet } from "./clientPublicTestnet.js";
+import { KnownScript } from "./knownScript.js";
+
+describe("Client known scripts", () => {
+  it("uses the network's default scripts", async () => {
+    const client = new ClientPublicTestnet();
+
+    const script = await client.getKnownScript(KnownScript.TypeId);
+
+    expect(script.codeHash).toBe(
+      "0x00000000000000000000000000000000000000000000000000545950455f4944",
+    );
+  });
+
+  it("uses a custom scripts registry", async () => {
+    const scripts = {
+      [KnownScript.TypeId]: {
+        codeHash:
+          "0x1111111111111111111111111111111111111111111111111111111111111111",
+        hashType: "data" as const,
+        cellDeps: [],
+      },
+    };
+    const client = new ClientPublicTestnet({ scripts });
+
+    const script = await client.getKnownScript(KnownScript.TypeId);
+
+    expect(client.scripts).toBe(scripts);
+    expect(script.codeHash).toBe(scripts[KnownScript.TypeId].codeHash);
+    await expect(client.getKnownScript(KnownScript.NervosDao)).rejects.toThrow(
+      "No script information was found for NervosDao on ckt",
+    );
+  });
+});

--- a/packages/core/src/client/clientLifecycle.test.ts
+++ b/packages/core/src/client/clientLifecycle.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { RequestorJsonRpc } from "../jsonRpc/requestor.js";
+import { JsonRpcTransport } from "../jsonRpc/transports/index.js";
+import { ClientPublicTestnet } from "./clientPublicTestnet.js";
+
+describe("Client ownership", () => {
+  it("disposes default transports owned by an opened Client", async () => {
+    const owner = ClientPublicTestnet.open({
+      urls: ["ws://example.com"],
+    });
+    const client = owner.value;
+
+    await owner.dispose();
+
+    await expect(
+      client.requestor.requestPayload(
+        client.requestor.buildPayload("test", []),
+      ),
+    ).rejects.toThrow("Cannot use a disposed JsonRpcTransportWebSocket");
+  });
+
+  it("creates a bare Client that borrows an externally provided transport", async () => {
+    const transport: JsonRpcTransport = {
+      request: async (payload) => ({
+        id: payload.id,
+        jsonrpc: "2.0",
+        result: "ok",
+      }),
+    };
+    const client = ClientPublicTestnet.new({
+      transport,
+    });
+
+    expect(client.requestor.transport).toBe(transport);
+
+    await expect(
+      client.requestor.requestPayload(
+        client.requestor.buildPayload("test", []),
+      ),
+    ).resolves.toBe("ok");
+  });
+
+  it("keeps legacy constructor Requestor injection compatible", () => {
+    const requestor = RequestorJsonRpc.new({
+      transport: {
+        request: async (payload) => ({
+          id: payload.id,
+          jsonrpc: "2.0",
+          result: "ok",
+        }),
+      },
+    });
+
+    const client = new ClientPublicTestnet({ requestor });
+
+    expect(client.requestor).toBe(requestor);
+  });
+});

--- a/packages/core/src/client/clientPublicMainnet.ts
+++ b/packages/core/src/client/clientPublicMainnet.ts
@@ -1,55 +1,94 @@
 import WebSocket from "isomorphic-ws";
+import { RequestorJsonRpc } from "../jsonRpc/requestor.js";
+import type { ClientConfig } from "./client.js";
 import { MAINNET_SCRIPTS } from "./clientPublicMainnet.advanced.js";
-import { ScriptInfo, ScriptInfoLike } from "./clientTypes.js";
-import { ClientJsonRpc, ClientJsonRpcConfig } from "./jsonRpc/index.js";
-import { KnownScript } from "./knownScript.js";
+import { ClientJsonRpc, type ClientJsonRpcConfig } from "./jsonRpc/client.js";
 
 /**
  * @public
  */
 export class ClientPublicMainnet extends ClientJsonRpc {
-  constructor(
-    private readonly config?: ClientJsonRpcConfig & {
-      url?: string;
-      scripts?: Record<KnownScript, ScriptInfoLike | undefined>;
-    },
-  ) {
-    const hasWebSocket = typeof WebSocket !== "undefined";
-    super(
-      config?.url ??
-        (hasWebSocket
-          ? "wss://mainnet.ckb.dev/ws"
-          : "https://mainnet.ckb.dev/"),
-      {
-        ...config,
-        fallbacks:
-          config?.fallbacks ??
-          (hasWebSocket
-            ? [
-                "wss://mainnet.ckb.dev/ws",
-                "https://mainnet.ckb.dev/",
-                "https://mainnet.ckbapp.dev/",
-              ]
-            : ["https://mainnet.ckb.dev/", "https://mainnet.ckbapp.dev/"]),
-      },
-    );
+  private static defaultUrls(): readonly [string, ...string[]] {
+    return typeof WebSocket !== "undefined"
+      ? [
+          "wss://mainnet.ckb.dev/ws",
+          "https://mainnet.ckb.dev/",
+          "https://mainnet.ckbapp.dev/",
+        ]
+      : ["https://mainnet.ckb.dev/", "https://mainnet.ckbapp.dev/"];
   }
 
-  get scripts(): Record<KnownScript, ScriptInfoLike | undefined> {
-    return this.config?.scripts ?? MAINNET_SCRIPTS;
+  private static resolveConfig(
+    config?: ClientJsonRpcConfig & {
+      /** @deprecated URL belongs to Transport construction. */
+      url?: string;
+    },
+  ): ClientJsonRpcConfig & { url: string; fallbacks: string[] } {
+    const defaultUrls = this.defaultUrls();
+    return {
+      ...config,
+      url: config?.url ?? defaultUrls[0],
+      fallbacks: config?.fallbacks ?? [...defaultUrls],
+      scripts: config?.scripts ?? MAINNET_SCRIPTS,
+    };
+  }
+
+  /**
+   * @deprecated Use {@link ClientPublicMainnet.new} with a borrowed Transport or
+   * {@link ClientPublicMainnet.open} when creating Transports.
+   */
+  constructor(
+    config?: ClientJsonRpcConfig & {
+      /** @deprecated URL belongs to Transport construction. */
+      url?: string;
+    },
+  ) {
+    const resolved = ClientPublicMainnet.resolveConfig(config);
+    super(resolved.url, resolved);
+  }
+
+  /** Creates a Client that borrows an existing Transport. */
+  static new(
+    config: Omit<Parameters<typeof RequestorJsonRpc.new>[0], "onError"> &
+      ClientConfig,
+  ): ClientPublicMainnet {
+    const { cache, scripts, ...requestorConfig } = config;
+    const requestor = this.newRequestor(requestorConfig);
+    return new ClientPublicMainnet({ cache, scripts, requestor });
+  }
+
+  /** Opens a Client with explicit ownership of its default dependencies. */
+  static open(
+    config?: Omit<
+      Parameters<typeof RequestorJsonRpc.open>[0],
+      "onError" | "urls"
+    > &
+      ClientConfig & {
+        urls?: Parameters<typeof RequestorJsonRpc.open>[0]["urls"];
+      },
+  ) {
+    const {
+      cache,
+      scripts,
+      urls = this.defaultUrls(),
+      ...requestorConfig
+    } = config ?? {};
+    return this.openRequestor({
+      ...requestorConfig,
+      urls,
+    }).map(
+      (requestor) =>
+        new ClientPublicMainnet({
+          cache,
+          scripts,
+          requestor,
+          url: urls[0],
+          fallbacks: [...urls.slice(1)],
+        }),
+    );
   }
 
   get addressPrefix(): string {
     return "ckb";
-  }
-
-  async getKnownScript(script: KnownScript): Promise<ScriptInfo> {
-    const found = this.scripts[script];
-    if (!found) {
-      throw new Error(
-        `No script information was found for ${script} on ${this.addressPrefix}`,
-      );
-    }
-    return ScriptInfo.from(found);
   }
 }

--- a/packages/core/src/client/clientPublicTestnet.ts
+++ b/packages/core/src/client/clientPublicTestnet.ts
@@ -1,55 +1,94 @@
 import WebSocket from "isomorphic-ws";
+import { RequestorJsonRpc } from "../jsonRpc/requestor.js";
+import type { ClientConfig } from "./client.js";
 import { TESTNET_SCRIPTS } from "./clientPublicTestnet.advanced.js";
-import { ScriptInfo, ScriptInfoLike } from "./clientTypes.js";
-import { ClientJsonRpc, ClientJsonRpcConfig } from "./jsonRpc/index.js";
-import { KnownScript } from "./knownScript.js";
+import { ClientJsonRpc, type ClientJsonRpcConfig } from "./jsonRpc/client.js";
 
 /**
  * @public
  */
 export class ClientPublicTestnet extends ClientJsonRpc {
-  constructor(
-    private readonly config?: ClientJsonRpcConfig & {
-      url?: string;
-      scripts?: Record<KnownScript, ScriptInfoLike | undefined>;
-    },
-  ) {
-    const hasWebSocket = typeof WebSocket !== "undefined";
-    super(
-      config?.url ??
-        (hasWebSocket
-          ? "wss://testnet.ckb.dev/ws"
-          : "https://testnet.ckb.dev/"),
-      {
-        ...config,
-        fallbacks:
-          config?.fallbacks ??
-          (hasWebSocket
-            ? [
-                "wss://testnet.ckb.dev/ws",
-                "https://testnet.ckb.dev/",
-                "https://testnet.ckbapp.dev/",
-              ]
-            : ["https://testnet.ckb.dev/", "https://testnet.ckbapp.dev/"]),
-      },
-    );
+  private static defaultUrls(): readonly [string, ...string[]] {
+    return typeof WebSocket !== "undefined"
+      ? [
+          "wss://testnet.ckb.dev/ws",
+          "https://testnet.ckb.dev/",
+          "https://testnet.ckbapp.dev/",
+        ]
+      : ["https://testnet.ckb.dev/", "https://testnet.ckbapp.dev/"];
   }
 
-  get scripts(): Record<KnownScript, ScriptInfoLike | undefined> {
-    return this.config?.scripts ?? TESTNET_SCRIPTS;
+  private static resolveConfig(
+    config?: ClientJsonRpcConfig & {
+      /** @deprecated URL belongs to Transport construction. */
+      url?: string;
+    },
+  ): ClientJsonRpcConfig & { url: string; fallbacks: string[] } {
+    const defaultUrls = this.defaultUrls();
+    return {
+      ...config,
+      url: config?.url ?? defaultUrls[0],
+      fallbacks: config?.fallbacks ?? [...defaultUrls],
+      scripts: config?.scripts ?? TESTNET_SCRIPTS,
+    };
+  }
+
+  /**
+   * @deprecated Use {@link ClientPublicTestnet.new} with a borrowed Transport or
+   * {@link ClientPublicTestnet.open} when creating Transports.
+   */
+  constructor(
+    config?: ClientJsonRpcConfig & {
+      /** @deprecated URL belongs to Transport construction. */
+      url?: string;
+    },
+  ) {
+    const resolved = ClientPublicTestnet.resolveConfig(config);
+    super(resolved.url, resolved);
+  }
+
+  /** Creates a Client that borrows an existing Transport. */
+  static new(
+    config: Omit<Parameters<typeof RequestorJsonRpc.new>[0], "onError"> &
+      ClientConfig,
+  ): ClientPublicTestnet {
+    const { cache, scripts, ...requestorConfig } = config;
+    const requestor = this.newRequestor(requestorConfig);
+    return new ClientPublicTestnet({ cache, scripts, requestor });
+  }
+
+  /** Opens a Client with explicit ownership of its default dependencies. */
+  static open(
+    config?: Omit<
+      Parameters<typeof RequestorJsonRpc.open>[0],
+      "onError" | "urls"
+    > &
+      ClientConfig & {
+        urls?: Parameters<typeof RequestorJsonRpc.open>[0]["urls"];
+      },
+  ) {
+    const {
+      cache,
+      scripts,
+      urls = this.defaultUrls(),
+      ...requestorConfig
+    } = config ?? {};
+    return this.openRequestor({
+      ...requestorConfig,
+      urls,
+    }).map(
+      (requestor) =>
+        new ClientPublicTestnet({
+          cache,
+          scripts,
+          requestor,
+          url: urls[0],
+          fallbacks: [...urls.slice(1)],
+        }),
+    );
   }
 
   get addressPrefix(): string {
     return "ckt";
-  }
-
-  async getKnownScript(script: KnownScript): Promise<ScriptInfo> {
-    const found = this.scripts[script];
-    if (!found) {
-      throw new Error(
-        `No script information was found for ${script} on ${this.addressPrefix}`,
-      );
-    }
-    return ScriptInfo.from(found);
   }
 }

--- a/packages/core/src/client/jsonRpc/client.ts
+++ b/packages/core/src/client/jsonRpc/client.ts
@@ -123,10 +123,6 @@ export abstract class ClientJsonRpc extends Client {
     return this.requestor.url;
   }
 
-  async close(): Promise<void> {
-    await this.requestor.close();
-  }
-
   /**
    * Get fee rate statistics
    *

--- a/packages/core/src/client/jsonRpc/client.ts
+++ b/packages/core/src/client/jsonRpc/client.ts
@@ -10,8 +10,8 @@ import {
   RequestorJsonRpcConfig,
 } from "../../jsonRpc/requestor.js";
 import { Num, NumLike, numFrom, numToHex } from "../../num/index.js";
-import { apply } from "../../utils/index.js";
-import { ClientCache } from "../cache/index.js";
+import { Owner, apply } from "../../utils/index.js";
+import type { ClientConfig } from "../client.js";
 import { Client } from "../client.js";
 import { DEFAULT_MIN_FEE_RATE } from "../clientTypes.advanced.js";
 import {
@@ -68,10 +68,35 @@ const ERROR_PARSERS: [
   ],
 ];
 
-export type ClientJsonRpcConfig = RequestorJsonRpcConfig & {
-  cache?: ClientCache;
-  requestor?: RequestorJsonRpc;
-};
+function handleJsonRpcError(errAny: unknown): never {
+  if (
+    typeof errAny !== "object" ||
+    errAny === null ||
+    !("data" in errAny) ||
+    typeof errAny.data !== "string"
+  ) {
+    throw errAny;
+  }
+  const err = errAny as ErrorClientBaseLike;
+
+  for (const [regexp, builder] of ERROR_PARSERS) {
+    const match = err.data.match(regexp);
+    if (match) {
+      throw builder(err, match);
+    }
+  }
+
+  throw new ErrorClientBase(err);
+}
+
+export type ClientJsonRpcConfig = RequestorJsonRpcConfig &
+  ClientConfig & {
+    /**
+     * @deprecated Requestor injection is supported only by legacy constructors.
+     * Use a borrowed Transport with `Client.new` or let `Client.open` create one.
+     */
+    requestor?: RequestorJsonRpc;
+  };
 
 /**
  * An abstract class implementing JSON-RPC client functionality for a specific URL and timeout.
@@ -85,42 +110,64 @@ export abstract class ClientJsonRpc extends Client {
    *
    * @param url_ - The URL of the JSON-RPC server.
    * @param timeout - The timeout for requests in milliseconds
+   * @deprecated Use the concrete Client's `new` or `open` method.
    */
 
-  constructor(url_: string, config?: ClientJsonRpcConfig) {
+  constructor(
+    private readonly url_: string,
+    config?: ClientJsonRpcConfig,
+  ) {
     super(config);
 
-    this.requestor =
-      config?.requestor ??
-      new RequestorJsonRpc(url_, config, (errAny) => {
-        if (
-          typeof errAny !== "object" ||
-          errAny === null ||
-          !("data" in errAny) ||
-          typeof errAny.data !== "string"
-        ) {
-          throw errAny;
-        }
-        const err = errAny as ErrorClientBaseLike;
-
-        for (const [regexp, builder] of ERROR_PARSERS) {
-          const match = err.data.match(regexp);
-          if (match) {
-            throw builder(err, match);
-          }
-        }
-
-        throw new ErrorClientBase(err);
+    const requestor = config?.requestor;
+    if (requestor) {
+      this.requestor = requestor;
+    } else if (config?.transport) {
+      this.requestor = RequestorJsonRpc.new({
+        transport: config.transport,
+        maxConcurrent: config.maxConcurrent,
+        onError: handleJsonRpcError,
       });
+    } else {
+      // Legacy constructor intentionally discards ownership.
+      this.requestor = RequestorJsonRpc.open({
+        urls: [url_, ...(config?.fallbacks ?? [])],
+        timeout: config?.timeout,
+        maxConcurrent: config?.maxConcurrent,
+        onError: handleJsonRpcError,
+      }).value;
+    }
+  }
+
+  /** Creates a Requestor that borrows an existing Transport. */
+  protected static newRequestor(
+    config: Omit<Parameters<typeof RequestorJsonRpc.new>[0], "onError">,
+  ): RequestorJsonRpc {
+    return RequestorJsonRpc.new({
+      ...config,
+      onError: handleJsonRpcError,
+    });
+  }
+
+  /** Opens a Requestor with ownership of its default Transport. */
+  protected static openRequestor(
+    config: Omit<Parameters<typeof RequestorJsonRpc.open>[0], "onError">,
+  ): Owner<RequestorJsonRpc> {
+    return RequestorJsonRpc.open({
+      ...config,
+      onError: handleJsonRpcError,
+    });
   }
 
   /**
-   * Returns the URL of the JSON-RPC server.
+   * Returns the legacy primary URL of the JSON-RPC server.
    *
    * @returns The URL of the JSON-RPC server.
+   * @deprecated A Client may use multiple endpoints or a Transport without a
+   * URL, so this value does not reliably identify its connection.
    */
   get url(): string {
-    return this.requestor.url;
+    return this.url_;
   }
 
   /**

--- a/packages/core/src/jsonRpc/requestor.test.ts
+++ b/packages/core/src/jsonRpc/requestor.test.ts
@@ -33,7 +33,7 @@ describe("RequestorJsonRpc", () => {
         return response(payload, payload.id);
       },
     };
-    const requestor = new RequestorJsonRpc("", {
+    const requestor = RequestorJsonRpc.new({
       maxConcurrent: 1,
       transport,
     });
@@ -102,5 +102,16 @@ describe("RequestorJsonRpc", () => {
       { status: "fulfilled", value: 2 },
       { status: "fulfilled", value: 3 },
     ]);
+  });
+
+  it("disposes default transports owned by an opened Requestor", async () => {
+    const owner = RequestorJsonRpc.open({ urls: ["ws://example.com"] });
+    const requestor = owner.value;
+
+    await owner.dispose();
+
+    await expect(
+      requestor.requestPayload(requestor.buildPayload("test", [])),
+    ).rejects.toThrow("Cannot use a disposed JsonRpcTransportWebSocket");
   });
 });

--- a/packages/core/src/jsonRpc/requestor.test.ts
+++ b/packages/core/src/jsonRpc/requestor.test.ts
@@ -15,20 +15,6 @@ function response(payload: JsonRpcPayload, result: unknown): JsonRpcResponse {
 }
 
 describe("RequestorJsonRpc", () => {
-  it("closes its transport", async () => {
-    const close = vi.fn();
-    const requestor = new RequestorJsonRpc("", {
-      transport: {
-        request: async (payload) => response(payload, "ok"),
-        close,
-      },
-    });
-
-    await requestor.close();
-
-    expect(close).toHaveBeenCalledOnce();
-  });
-
   it("advances the queue after a successful request", async () => {
     let releaseFirst: (() => void) | undefined;
     const firstPending = new Promise<void>((resolve) => {
@@ -37,7 +23,6 @@ describe("RequestorJsonRpc", () => {
     let active = 0;
     let maxActive = 0;
     const transport: JsonRpcTransport = {
-      async close() {},
       async request(payload) {
         active += 1;
         maxActive = Math.max(maxActive, active);
@@ -65,7 +50,6 @@ describe("RequestorJsonRpc", () => {
   it("advances the queue after a transport error", async () => {
     let calls = 0;
     const transport: JsonRpcTransport = {
-      async close() {},
       async request(payload) {
         calls += 1;
         if (calls === 1) {
@@ -92,7 +76,6 @@ describe("RequestorJsonRpc", () => {
   it("does not exhaust a larger concurrency limit after transport errors", async () => {
     let calls = 0;
     const transport: JsonRpcTransport = {
-      async close() {},
       async request(payload) {
         calls += 1;
         if (calls <= 2) {

--- a/packages/core/src/jsonRpc/requestor.test.ts
+++ b/packages/core/src/jsonRpc/requestor.test.ts
@@ -58,7 +58,7 @@ describe("RequestorJsonRpc", () => {
         return response(payload, "ok");
       },
     };
-    const requestor = new RequestorJsonRpc("", {
+    const requestor = RequestorJsonRpc.new({
       maxConcurrent: 1,
       transport,
     });
@@ -84,7 +84,7 @@ describe("RequestorJsonRpc", () => {
         return response(payload, payload.id);
       },
     };
-    const requestor = new RequestorJsonRpc("", {
+    const requestor = RequestorJsonRpc.new({
       maxConcurrent: 2,
       transport,
     });

--- a/packages/core/src/jsonRpc/requestor.ts
+++ b/packages/core/src/jsonRpc/requestor.ts
@@ -74,10 +74,6 @@ export class RequestorJsonRpc {
     return this.url_;
   }
 
-  async close(): Promise<void> {
-    await this.transport.close();
-  }
-
   /**
    * request a JSON-RPC method.
    *

--- a/packages/core/src/jsonRpc/requestor.ts
+++ b/packages/core/src/jsonRpc/requestor.ts
@@ -1,10 +1,24 @@
+import { OwnerAggregated } from "../utils/owner/aggregated.js";
+import { Owner } from "../utils/owner/owner.js";
 import { jsonRpcTransportFromUri } from "./transports/factory.js";
+import { JsonRpcTransportFallback } from "./transports/fallback.js";
 import {
   JsonRpcPayload,
   JsonRpcResponse,
   JsonRpcTransport,
-  JsonRpcTransportFallback,
 } from "./transports/index.js";
+
+function openTransports(
+  urls: readonly [string, ...string[]],
+  config?: { timeout?: number },
+): Owner<JsonRpcTransportFallback> {
+  const transportOwners = Array.from(new Set(urls), (url) =>
+    jsonRpcTransportFromUri(url, config),
+  );
+  return OwnerAggregated.from(transportOwners).map(
+    (transports) => new JsonRpcTransportFallback([...transports]),
+  );
+}
 
 /**
  * Applies a transformation function to a value if the transformer is provided.
@@ -26,6 +40,10 @@ function transform(value: unknown, transformer?: (i: unknown) => unknown) {
   return value;
 }
 
+/**
+ * @deprecated Used only by the legacy positional constructor. Use the static
+ * {@link RequestorJsonRpc.new} or {@link RequestorJsonRpc.open} methods.
+ */
 export type RequestorJsonRpcConfig = {
   fallbacks?: string[];
   timeout?: number;
@@ -43,10 +61,12 @@ export class RequestorJsonRpc {
   private id = 0;
 
   /**
-   * Creates an instance of ClientJsonRpc.
+   * Creates a Requestor using legacy positional arguments.
    *
    * @param url_ - The URL of the JSON-RPC server.
    * @param timeout - The timeout for requests in milliseconds
+   * @deprecated Use {@link RequestorJsonRpc.new} with a borrowed Transport or
+   * {@link RequestorJsonRpc.open} when creating Transports.
    */
   constructor(
     private readonly url_: string,
@@ -54,20 +74,56 @@ export class RequestorJsonRpc {
     private readonly onError?: (err: unknown) => Promise<void> | void,
   ) {
     this.maxConcurrent = config?.maxConcurrent;
-    this.transport =
-      config?.transport ??
-      new JsonRpcTransportFallback(
-        Array.from(
-          new Set([url_, ...(config?.fallbacks ?? [])]).values(),
-          (url) => jsonRpcTransportFromUri(url, config),
-        ),
-      );
+    if (config?.transport) {
+      this.transport = config.transport;
+    } else {
+      this.transport = openTransports(
+        [url_, ...(config?.fallbacks ?? [])],
+        config,
+      ).value;
+    }
+  }
+
+  /** Creates a Requestor that borrows an existing Transport. */
+  static new({
+    transport,
+    maxConcurrent,
+    onError,
+  }: {
+    transport: JsonRpcTransport;
+    maxConcurrent?: number;
+    onError?: (err: unknown) => Promise<void> | void;
+  }): RequestorJsonRpc {
+    return new RequestorJsonRpc("", { transport, maxConcurrent }, onError);
+  }
+
+  /** Opens a Requestor with ownership of its default transports. */
+  static open({
+    urls: [url, ...fallbacks],
+    onError,
+    ...config
+  }: {
+    urls: readonly [string, ...string[]];
+    timeout?: number;
+    maxConcurrent?: number;
+    onError?: (err: unknown) => Promise<void> | void;
+  }): Owner<RequestorJsonRpc> {
+    const transportOwner = openTransports([url, ...fallbacks], config);
+    return transportOwner.map((transport) =>
+      RequestorJsonRpc.new({
+        transport,
+        ...config,
+        onError,
+      }),
+    );
   }
 
   /**
    * Returns the URL of the JSON-RPC server.
    *
    * @returns The URL of the JSON-RPC server.
+   * @deprecated URL belongs to Transport construction and is unavailable for
+   * Requestors created with {@link RequestorJsonRpc.new}.
    */
 
   get url(): string {

--- a/packages/core/src/jsonRpc/transports/factory.ts
+++ b/packages/core/src/jsonRpc/transports/factory.ts
@@ -1,3 +1,4 @@
+import { OwnerUnique } from "../../utils/owner/unique.js";
 import { JsonRpcTransportHttp } from "./http.js";
 import { JsonRpcTransportWebSocket } from "./webSocket.js";
 
@@ -6,8 +7,11 @@ export function jsonRpcTransportFromUri(
   config?: { timeout?: number },
 ) {
   if (uri.startsWith("wss://") || uri.startsWith("ws://")) {
-    return new JsonRpcTransportWebSocket(uri, config?.timeout);
+    return JsonRpcTransportWebSocket.open(uri, config?.timeout);
   }
 
-  return new JsonRpcTransportHttp(uri, config?.timeout);
+  return new OwnerUnique(
+    new JsonRpcTransportHttp(uri, config?.timeout),
+    () => {},
+  );
 }

--- a/packages/core/src/jsonRpc/transports/fallback.test.ts
+++ b/packages/core/src/jsonRpc/transports/fallback.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { JsonRpcTransportFallback } from "./fallback.js";
 import {
   JsonRpcPayload,
@@ -21,41 +21,10 @@ const response: JsonRpcResponse = {
 function makeTransport(
   handler: () => Promise<JsonRpcResponse>,
 ): JsonRpcTransport {
-  return { request: () => handler(), async close() {} };
+  return { request: () => handler() };
 }
 
 describe("JsonRpcTransportFallback", () => {
-  it("closes every transport", async () => {
-    const closeA = vi.fn();
-    const closeB = vi.fn();
-    const transport = new JsonRpcTransportFallback([
-      { request: async () => response, close: closeA },
-      { request: async () => response, close: closeB },
-    ]);
-
-    await transport.close();
-
-    expect(closeA).toHaveBeenCalledOnce();
-    expect(closeB).toHaveBeenCalledOnce();
-  });
-
-  it("starts closing every transport when one close throws synchronously", async () => {
-    const error = new Error("close failed");
-    const closeA = vi.fn(() => {
-      throw error;
-    });
-    const closeB = vi.fn(async () => {});
-    const transport = new JsonRpcTransportFallback([
-      { request: async () => response, close: closeA },
-      { request: async () => response, close: closeB },
-    ]);
-
-    await expect(transport.close()).rejects.toBe(error);
-
-    expect(closeA).toHaveBeenCalledOnce();
-    expect(closeB).toHaveBeenCalledOnce();
-  });
-
   it("returns result from the first healthy transport", async () => {
     const transport = new JsonRpcTransportFallback([
       makeTransport(() => Promise.resolve(response)),

--- a/packages/core/src/jsonRpc/transports/fallback.ts
+++ b/packages/core/src/jsonRpc/transports/fallback.ts
@@ -31,10 +31,4 @@ export class JsonRpcTransportFallback implements JsonRpcTransport {
 
     throw lastErr;
   }
-
-  async close(): Promise<void> {
-    await Promise.all(
-      this.transports.map(async (transport) => transport.close()),
-    );
-  }
 }

--- a/packages/core/src/jsonRpc/transports/http.ts
+++ b/packages/core/src/jsonRpc/transports/http.ts
@@ -29,6 +29,4 @@ export class JsonRpcTransportHttp implements JsonRpcTransport {
       clearTimeout(abortTimer);
     }
   }
-
-  async close(): Promise<void> {}
 }

--- a/packages/core/src/jsonRpc/transports/transport.ts
+++ b/packages/core/src/jsonRpc/transports/transport.ts
@@ -29,7 +29,4 @@ export interface JsonRpcTransport {
    * @returns The JSON-RPC response.
    */
   request(payload: JsonRpcPayload): Promise<JsonRpcResponse>;
-
-  /** Releases resources held by the transport. */
-  close(): Promise<void>;
 }

--- a/packages/core/src/jsonRpc/transports/webSocket.test.ts
+++ b/packages/core/src/jsonRpc/transports/webSocket.test.ts
@@ -83,7 +83,8 @@ describe("JsonRpcTransportWebSocket", () => {
   });
 
   it("closes its socket", async () => {
-    const transport = new JsonRpcTransportWebSocket("ws://example.com");
+    const owner = JsonRpcTransportWebSocket.open("ws://example.com");
+    const transport = owner.value;
     await transport.request({
       id: 0,
       jsonrpc: "2.0",
@@ -93,13 +94,34 @@ describe("JsonRpcTransportWebSocket", () => {
     expect(mock.sockets).toHaveLength(1);
     expect(mock.sockets[0].closed).toBe(false);
 
-    await transport.close();
+    await owner.dispose();
 
     expect(mock.sockets[0].closed).toBe(true);
+    expect(() => owner.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+  });
+
+  it("does not reconnect through a stale borrow after disposal", async () => {
+    const owner = JsonRpcTransportWebSocket.open("ws://example.com");
+    const transport = owner.value;
+
+    await owner.dispose();
+
+    await expect(
+      transport.request({
+        id: 0,
+        jsonrpc: "2.0",
+        method: "test",
+        params: [],
+      }),
+    ).rejects.toThrow("Cannot use a disposed JsonRpcTransportWebSocket");
+    expect(mock.sockets).toHaveLength(0);
   });
 
   it("correlates responses with string IDs", async () => {
-    const transport = new JsonRpcTransportWebSocket("ws://example.com");
+    const owner = JsonRpcTransportWebSocket.open("ws://example.com");
+    const transport = owner.value;
 
     await expect(
       transport.request({
@@ -110,13 +132,14 @@ describe("JsonRpcTransportWebSocket", () => {
       }),
     ).resolves.toMatchObject({ id: "request-0", result: "ok" });
 
-    await transport.close();
+    await owner.dispose();
   });
 
   it("ignores invalid JSON until the request times out", async () => {
     vi.useFakeTimers();
     mock.invalidResponse = true;
-    const transport = new JsonRpcTransportWebSocket("ws://example.com", 100);
+    const owner = JsonRpcTransportWebSocket.open("ws://example.com", 100);
+    const transport = owner.value;
 
     const request = expect(
       transport.request({
@@ -131,13 +154,15 @@ describe("JsonRpcTransportWebSocket", () => {
     await request;
 
     expect(mock.sockets[0].closed).toBe(true);
+    await owner.dispose();
   });
 
   it("cleans up the request timeout when send throws", async () => {
     vi.useFakeTimers();
     const error = new Error("send failed");
     mock.sendError = error;
-    const transport = new JsonRpcTransportWebSocket("ws://example.com", 100);
+    const owner = JsonRpcTransportWebSocket.open("ws://example.com", 100);
+    const transport = owner.value;
 
     await expect(
       transport.request({
@@ -151,12 +176,14 @@ describe("JsonRpcTransportWebSocket", () => {
     await vi.advanceTimersByTimeAsync(100);
 
     expect(mock.sockets[0].closeCalls).toBe(0);
+    await owner.dispose();
   });
 
   it("closes a connecting socket without sending after timeout", async () => {
     vi.useFakeTimers();
     mock.deferOpen = true;
-    const transport = new JsonRpcTransportWebSocket("ws://example.com", 100);
+    const owner = JsonRpcTransportWebSocket.open("ws://example.com", 100);
+    const transport = owner.value;
 
     const request = expect(
       transport.request({
@@ -176,5 +203,6 @@ describe("JsonRpcTransportWebSocket", () => {
     await Promise.resolve();
 
     expect(mock.sockets[0].sent).toHaveLength(0);
+    await owner.dispose();
   });
 });

--- a/packages/core/src/jsonRpc/transports/webSocket.ts
+++ b/packages/core/src/jsonRpc/transports/webSocket.ts
@@ -124,15 +124,4 @@ export class JsonRpcTransportWebSocket implements JsonRpcTransport {
         });
     });
   }
-
-  async close(): Promise<void> {
-    const socket = this.socket;
-
-    if (!socket || socket.readyState === socket.CLOSED) return;
-
-    await new Promise<void>((resolve) => {
-      socket.addEventListener("close", () => resolve(), { once: true });
-      socket.close();
-    });
-  }
 }

--- a/packages/core/src/jsonRpc/transports/webSocket.ts
+++ b/packages/core/src/jsonRpc/transports/webSocket.ts
@@ -1,4 +1,5 @@
 import WebSocket from "isomorphic-ws";
+import { OwnerUnique } from "../../utils/owner/unique.js";
 import {
   JsonRpcId,
   JsonRpcPayload,
@@ -15,15 +16,36 @@ export class JsonRpcTransportWebSocket implements JsonRpcTransport {
       ReturnType<typeof setTimeout>,
     ]
   > = new Map();
+  private disposed = false;
   private socket?: WebSocket;
   private openSocket?: Promise<WebSocket>;
 
+  /**
+   * @deprecated Use {@link JsonRpcTransportWebSocket.open} to make lifecycle
+   * ownership explicit. This constructor will become private in a future
+   * release.
+   */
   constructor(
     private readonly url: string,
     private readonly timeout = 30000,
   ) {}
 
+  /** Opens an owned WebSocket transport. */
+  static open(
+    url: string,
+    timeout = 30000,
+  ): OwnerUnique<JsonRpcTransportWebSocket> {
+    const transport = new JsonRpcTransportWebSocket(url, timeout);
+    return new OwnerUnique(transport, (transport) => transport.dispose());
+  }
+
   request(data: JsonRpcPayload): Promise<JsonRpcResponse> {
+    if (this.disposed) {
+      return Promise.reject(
+        new Error("Cannot use a disposed JsonRpcTransportWebSocket"),
+      );
+    }
+
     const [socketUnsafe, socket] = (() => {
       if (
         this.socket &&
@@ -122,6 +144,18 @@ export class JsonRpcTransportWebSocket implements JsonRpcTransport {
           this.ongoing.delete(data.id);
           reject(err);
         });
+    });
+  }
+
+  private async dispose(): Promise<void> {
+    this.disposed = true;
+    const socket = this.socket;
+
+    if (!socket || socket.readyState === socket.CLOSED) return;
+
+    await new Promise<void>((resolve) => {
+      socket.addEventListener("close", () => resolve(), { once: true });
+      socket.close();
     });
   }
 }

--- a/packages/core/src/signer/ckb/secp256k1Signing.test.ts
+++ b/packages/core/src/signer/ckb/secp256k1Signing.test.ts
@@ -7,7 +7,13 @@ import {
   verifyMessageSecp256k1,
 } from "./secp256k1Signing.js";
 
-const client = new ccc.ClientPublicTestnet();
+const client = ccc.ClientPublicTestnet.new({
+  transport: {
+    request: async () => {
+      throw new Error("Unexpected request");
+    },
+  },
+});
 const signer = new ccc.SignerCkbPrivateKey(
   client,
   "0x0123456789012345678901234567890123456789012345678901234567890123",

--- a/packages/core/src/signer/ckb/signerMultisigCkb.test.ts
+++ b/packages/core/src/signer/ckb/signerMultisigCkb.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { ccc } from "../../index.js";
 
-const client = new ccc.ClientPublicTestnet();
+const client = ccc.ClientPublicTestnet.new({
+  transport: {
+    request: async () => {
+      throw new Error("Unexpected request");
+    },
+  },
+});
 const ZERO_HASH =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,7 @@ import { Zero } from "../fixedPoint/index.js";
 import { NumLike, numFrom, numToHex, type Num } from "../num/index.js";
 
 export * from "./constructor.js";
+export * from "./owner/index.js";
 export * from "./proxy.js";
 
 /**

--- a/packages/core/src/utils/owner/aggregated.test.ts
+++ b/packages/core/src/utils/owner/aggregated.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { OwnerAggregated } from "./aggregated.js";
+import { OwnerUnique } from "./unique.js";
+
+describe("OwnerAggregated", () => {
+  it("moves heterogeneous ownership claims", async () => {
+    const disposeString = vi.fn();
+    const disposeNumber = vi.fn();
+    const stringOwner = new OwnerUnique("value", disposeString);
+    const numberOwner = new OwnerUnique(42, disposeNumber);
+
+    const owner = OwnerAggregated.from([stringOwner, numberOwner] as const);
+
+    expect(owner.value).toEqual(["value", 42]);
+    expect(() => stringOwner.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    await Promise.all([stringOwner.dispose(), numberOwner.dispose()]);
+    expect(disposeString).not.toHaveBeenCalled();
+    expect(disposeNumber).not.toHaveBeenCalled();
+
+    await owner.dispose();
+    expect(disposeString).toHaveBeenCalledOnce();
+    expect(disposeNumber).toHaveBeenCalledOnce();
+  });
+
+  it("rejects duplicate Owners before moving them", () => {
+    const source = new OwnerUnique("value", vi.fn());
+
+    expect(() => OwnerAggregated.from([source, source])).toThrow(
+      "Cannot aggregate the same Owner more than once",
+    );
+    expect(source.value).toBe("value");
+  });
+
+  it("validates every Owner before moving any of them", async () => {
+    const active = new OwnerUnique("active", vi.fn());
+    const disposed = new OwnerUnique("disposed", vi.fn());
+    await disposed.dispose();
+
+    expect(() => OwnerAggregated.from([active, disposed])).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    expect(active.value).toBe("active");
+  });
+
+  it("waits for every Owner and aggregates disposal failures", async () => {
+    const firstError = new Error("first failed");
+    const secondError = new Error("second failed");
+    const disposeFirst = vi.fn(() => {
+      throw firstError;
+    });
+    const disposeSecond = vi.fn(() => {
+      throw secondError;
+    });
+    const owner = OwnerAggregated.from([
+      new OwnerUnique("first", disposeFirst),
+      new OwnerUnique("second", disposeSecond),
+    ]);
+
+    await expect(owner.dispose()).rejects.toMatchObject({
+      errors: [firstError, secondError],
+    });
+    expect(disposeFirst).toHaveBeenCalledOnce();
+    expect(disposeSecond).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/utils/owner/aggregated.ts
+++ b/packages/core/src/utils/owner/aggregated.ts
@@ -1,0 +1,56 @@
+import { Owner, OwnerMoved } from "./owner.js";
+
+// TypeScript has no existential type for heterogeneous Owner values.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Owners = readonly Owner<any>[];
+
+type OwnerValues<T extends Owners> = {
+  [K in keyof T]: T[K] extends Owner<infer U> ? U : never;
+};
+
+/**
+ * An Owner that aggregates multiple ownership claims.
+ *
+ * Disposing it attempts to release every claim and aggregates any failures.
+ *
+ * @public
+ */
+export class OwnerAggregated<T extends readonly unknown[]> extends Owner<T> {
+  private constructor(
+    protected readonly value_: T,
+    private readonly owners: readonly OwnerMoved<unknown>[],
+  ) {
+    super();
+  }
+
+  /** Moves multiple ownership claims into one Owner. */
+  static from<const TOwners extends Owners>(
+    owners: TOwners,
+  ): OwnerAggregated<OwnerValues<TOwners>> {
+    if (new Set(owners).size !== owners.length) {
+      throw new Error("Cannot aggregate the same Owner more than once");
+    }
+
+    // Validate every source before moving any of them.
+    const values = owners.map(
+      (owner): unknown => owner.value,
+    ) as OwnerValues<TOwners>;
+    const moved = owners.map((owner) => this.moveFrom(owner));
+    return new OwnerAggregated(values, moved);
+  }
+
+  protected async release(): Promise<void> {
+    const results = await Promise.allSettled(
+      this.owners.map((owner) => owner.dispose()),
+    );
+    const errors: unknown[] = [];
+    for (const result of results) {
+      if (result.status === "rejected") {
+        errors.push(result.reason as unknown);
+      }
+    }
+    if (errors.length !== 0) {
+      throw new AggregateError(errors, "Failed to dispose aggregated Owners");
+    }
+  }
+}

--- a/packages/core/src/utils/owner/index.ts
+++ b/packages/core/src/utils/owner/index.ts
@@ -1,3 +1,4 @@
+export * from "./aggregated.js";
 export * from "./owner.js";
 export * from "./refCount.js";
 export * from "./unique.js";

--- a/packages/core/src/utils/owner/index.ts
+++ b/packages/core/src/utils/owner/index.ts
@@ -1,2 +1,3 @@
 export * from "./owner.js";
+export * from "./refCount.js";
 export * from "./unique.js";

--- a/packages/core/src/utils/owner/index.ts
+++ b/packages/core/src/utils/owner/index.ts
@@ -1,0 +1,2 @@
+export * from "./owner.js";
+export * from "./unique.js";

--- a/packages/core/src/utils/owner/owner.test.ts
+++ b/packages/core/src/utils/owner/owner.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { OwnerMoved } from "./owner.js";
+
+describe("OwnerMoved", () => {
+  it("disposes only once and returns the same result", async () => {
+    const dispose = vi.fn(async () => {});
+    const owner = new OwnerMoved("value", dispose);
+
+    const first = owner.dispose();
+    const second = owner.dispose();
+
+    expect(second).toBe(first);
+    await Promise.all([first, second]);
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledWith("value");
+  });
+
+  it("caches a disposal failure", async () => {
+    const error = new Error("dispose failed");
+    const dispose = vi.fn(() => {
+      throw error;
+    });
+    const owner = new OwnerMoved("value", dispose);
+
+    const first = owner.dispose();
+    const second = owner.dispose();
+
+    expect(second).toBe(first);
+    await expect(first).rejects.toBe(error);
+    await expect(second).rejects.toBe(error);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/utils/owner/owner.test.ts
+++ b/packages/core/src/utils/owner/owner.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it, vi } from "vitest";
 import { OwnerMoved } from "./owner.js";
+import { OwnerUnique } from "./unique.js";
+
+describe("Owner", () => {
+  it("maps and transfers an ownership claim", async () => {
+    const dispose = vi.fn();
+    const source = new OwnerUnique("value", dispose);
+
+    const mapped = source.map((value) => ({ value }));
+
+    expect(mapped.value).toEqual({ value: "value" });
+    expect(() => source.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    await source.dispose();
+    expect(dispose).not.toHaveBeenCalled();
+
+    await mapped.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledWith("value");
+  });
+
+  it("keeps the source active when mapping fails", () => {
+    const source = new OwnerUnique("value", vi.fn());
+    const error = new Error("mapping failed");
+
+    expect(() =>
+      source.map(() => {
+        throw error;
+      }),
+    ).toThrow(error);
+    expect(source.value).toBe("value");
+  });
+});
 
 describe("OwnerMoved", () => {
   it("disposes only once and returns the same result", async () => {

--- a/packages/core/src/utils/owner/owner.test.ts
+++ b/packages/core/src/utils/owner/owner.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
-import { OwnerMoved } from "./owner.js";
+import { Owner, OwnerMoved } from "./owner.js";
 import { OwnerUnique } from "./unique.js";
 
 describe("Owner", () => {
+  it("uses a global runtime brand", () => {
+    const owner = new OwnerUnique("value", vi.fn());
+    const crossPackageOwner = {
+      [Symbol.for("@ckb-ccc/core.Owner")]: true,
+    };
+
+    expect(Owner.is(owner)).toBe(true);
+    expect(Owner.is(crossPackageOwner)).toBe(true);
+    expect(Owner.is({ value: "value", map() {}, dispose() {} })).toBe(false);
+  });
+
   it("maps and transfers an ownership claim", async () => {
     const dispose = vi.fn();
     const source = new OwnerUnique("value", dispose);

--- a/packages/core/src/utils/owner/owner.ts
+++ b/packages/core/src/utils/owner/owner.ts
@@ -1,0 +1,99 @@
+/**
+ * An ownership claim moved out of an {@link Owner}.
+ *
+ * @public
+ */
+export class OwnerMoved<T> {
+  private disposing?: Promise<void>;
+
+  constructor(
+    /** The owned value. */
+    readonly value: T,
+    private readonly disposer: (value: T) => PromiseLike<void> | void,
+  ) {}
+
+  /** Disposes this ownership claim. */
+  dispose(): Promise<void> {
+    this.disposing ??= Promise.resolve().then(() => this.disposer(this.value));
+    return this.disposing;
+  }
+}
+
+/**
+ * Owns the lifecycle of a value.
+ *
+ * @example
+ * ```ts
+ * class ConnectionOwner extends Owner<Connection> {
+ *   constructor(protected readonly value_: Connection) {
+ *     super();
+ *   }
+ *
+ *   protected release(connection: Connection): Promise<void> {
+ *     return connection.close();
+ *   }
+ * }
+ * ```
+ *
+ * @public
+ */
+export abstract class Owner<T> {
+  protected abstract readonly value_: T;
+
+  private disposing?: Promise<void>;
+
+  /**
+   * The owned value.
+   *
+   * @throws If this ownership has been moved or disposed.
+   */
+  get value(): T {
+    if (this.disposing) {
+      throw new Error("Cannot access a moved or disposed Owner");
+    }
+    return this.value_;
+  }
+
+  /**
+   * Releases this ownership claim.
+   *
+   * Implementations decide whether this disposes the value immediately or,
+   * for example, only decrements a reference count.
+   */
+  protected abstract release(value: T): PromiseLike<void> | void;
+
+  /**
+   * Disposes this ownership claim. Repeated calls are safe.
+   */
+  dispose(): Promise<void> {
+    this.disposing ??= Promise.resolve().then(() => this.release(this.value_));
+    return this.disposing;
+  }
+
+  /**
+   * Moves the ownership claim out of this owner without disposing it.
+   *
+   * Access is invalidated synchronously and the moved claim retains this
+   * Owner's release semantics.
+   *
+   * @throws If this owner no longer has an ownership claim.
+   */
+  protected move(): OwnerMoved<T> {
+    if (this.disposing) {
+      throw new Error("Owner has already been moved or disposed");
+    }
+
+    this.disposing = Promise.resolve();
+
+    return new OwnerMoved(this.value_, (value) => this.release(value));
+  }
+
+  /**
+   * Moves an ownership claim between Owner implementations.
+   *
+   * @throws If the source owner has already been moved or disposed.
+   */
+  protected static moveFrom<T>(owner: Owner<T>): OwnerMoved<T> {
+    return owner.move();
+  }
+}

--- a/packages/core/src/utils/owner/owner.ts
+++ b/packages/core/src/utils/owner/owner.ts
@@ -71,6 +71,18 @@ export abstract class Owner<T> {
   }
 
   /**
+   * Maps the owned value while transferring this ownership claim.
+   *
+   * The mapper runs before the claim is moved, so a mapper failure leaves this
+   * Owner active. After a successful mapping, this Owner is invalidated and the
+   * returned Owner retains its release semantics.
+   */
+  map<U>(mapper: (value: T) => U): Owner<U> {
+    const value = mapper(this.value);
+    return new OwnerMapped(value, this.move());
+  }
+
+  /**
    * Moves the ownership claim out of this owner without disposing it.
    *
    * Access is invalidated synchronously and the moved claim retains this
@@ -95,5 +107,18 @@ export abstract class Owner<T> {
    */
   protected static moveFrom<T>(owner: Owner<T>): OwnerMoved<T> {
     return owner.move();
+  }
+}
+
+class OwnerMapped<TValue, TSource> extends Owner<TValue> {
+  constructor(
+    protected readonly value_: TValue,
+    private readonly source: OwnerMoved<TSource>,
+  ) {
+    super();
+  }
+
+  protected release() {
+    return this.source.dispose();
   }
 }

--- a/packages/core/src/utils/owner/owner.ts
+++ b/packages/core/src/utils/owner/owner.ts
@@ -19,6 +19,8 @@ export class OwnerMoved<T> {
   }
 }
 
+const ownerId = Symbol.for("@ckb-ccc/core.Owner");
+
 /**
  * Owns the lifecycle of a value.
  *
@@ -40,7 +42,17 @@ export class OwnerMoved<T> {
 export abstract class Owner<T> {
   protected abstract readonly value_: T;
 
+  private readonly [ownerId] = true;
   private disposing?: Promise<void>;
+
+  /** Returns whether a value implements CCC Owner semantics. */
+  static is(value: unknown): value is Owner<unknown> {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      (value as { [ownerId]?: unknown })[ownerId] === true
+    );
+  }
 
   /**
    * The owned value.

--- a/packages/core/src/utils/owner/refCount.test.ts
+++ b/packages/core/src/utils/owner/refCount.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { OwnerRefCount } from "./refCount.js";
+import { OwnerUnique } from "./unique.js";
+
+describe("OwnerRefCount", () => {
+  it("disposes the source ownership after the final reference", async () => {
+    const dispose = vi.fn(async () => {});
+    const first = OwnerRefCount.new("value", dispose);
+    const second = first.clone();
+
+    await first.dispose();
+    expect(dispose).not.toHaveBeenCalled();
+    expect(second.value).toBe("value");
+
+    await second.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledWith("value");
+  });
+
+  it("moves the source ownership", async () => {
+    const dispose = vi.fn();
+    const source = new OwnerUnique("value", dispose);
+    const owner = OwnerRefCount.from(source);
+
+    expect(() => source.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+
+    await source.dispose();
+    expect(dispose).not.toHaveBeenCalled();
+
+    await owner.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("releases each reference only once", async () => {
+    const dispose = vi.fn();
+    const first = OwnerRefCount.from(new OwnerUnique("value", dispose));
+    const second = first.clone();
+
+    await Promise.all([
+      first.dispose(),
+      first.dispose(),
+      second.dispose(),
+      second.dispose(),
+    ]);
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("rejects access and cloning through a disposed reference", async () => {
+    const owner = OwnerRefCount.from(new OwnerUnique("value", () => {}));
+    await owner.dispose();
+
+    expect(() => owner.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    expect(() => owner.clone()).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+  });
+});

--- a/packages/core/src/utils/owner/refCount.ts
+++ b/packages/core/src/utils/owner/refCount.ts
@@ -1,0 +1,78 @@
+import { Owner, OwnerMoved } from "./owner.js";
+
+type OwnerRefCountState<T> = {
+  owner: OwnerMoved<T>;
+  referenceCount: number;
+};
+
+/**
+ * A reference-counted Owner for a shared value.
+ *
+ * The source ownership is disposed after the final OwnerRefCount is disposed.
+ * Each clone owns one reference and can be disposed independently.
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * const first = OwnerRefCount.new(
+ *   controller,
+ *   (controller) => controller.abort(),
+ * );
+ * const second = first.clone();
+ *
+ * await first.dispose();
+ * console.log(controller.signal.aborted); // false
+ *
+ * await second.dispose();
+ * console.log(controller.signal.aborted); // true
+ * ```
+ *
+ * @public
+ */
+export class OwnerRefCount<T> extends Owner<T> {
+  private constructor(private readonly state: OwnerRefCountState<T>) {
+    super();
+  }
+
+  protected get value_(): T {
+    return this.state.owner.value;
+  }
+
+  /** Creates the first reference-counted Owner for a value. */
+  static new<T>(
+    value: T,
+    disposer: (value: T) => PromiseLike<void> | void,
+  ): OwnerRefCount<T> {
+    return new OwnerRefCount({
+      owner: new OwnerMoved(value, disposer),
+      referenceCount: 1,
+    });
+  }
+
+  /**
+   * Moves an ownership claim into a new reference-counted Owner.
+   *
+   * @throws If the source Owner has already been moved or disposed.
+   */
+  static from<T>(owner: Owner<T>): OwnerRefCount<T> {
+    return new OwnerRefCount({
+      owner: this.moveFrom(owner),
+      referenceCount: 1,
+    });
+  }
+
+  /** Creates another Owner for the same shared value. */
+  clone(): OwnerRefCount<T> {
+    // Assert that this Owner is still active before adding a reference.
+    void this.value;
+    this.state.referenceCount += 1;
+    return new OwnerRefCount(this.state);
+  }
+
+  protected release(): Promise<void> | void {
+    this.state.referenceCount -= 1;
+    if (this.state.referenceCount === 0) {
+      return this.state.owner.dispose();
+    }
+  }
+}

--- a/packages/core/src/utils/owner/unique.test.ts
+++ b/packages/core/src/utils/owner/unique.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { Owner, OwnerMoved } from "./owner.js";
+import { OwnerUnique } from "./unique.js";
+
+class OwnerTransferred<T> extends Owner<T> {
+  private readonly moved: OwnerMoved<T>;
+  protected readonly value_: T;
+
+  private constructor(moved: OwnerMoved<T>) {
+    super();
+    this.moved = moved;
+    this.value_ = moved.value;
+  }
+
+  static from<T>(owner: Owner<T>): OwnerTransferred<T> {
+    return new OwnerTransferred(this.moveFrom(owner));
+  }
+
+  protected release() {
+    return this.moved.dispose();
+  }
+}
+
+describe("OwnerUnique", () => {
+  it("exposes and disposes its value", async () => {
+    const dispose = vi.fn();
+    const owner = new OwnerUnique("value", dispose);
+
+    expect(owner.value).toBe("value");
+    await owner.dispose();
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(dispose).toHaveBeenCalledWith("value");
+    expect(() => owner.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+  });
+
+  it("invalidates access before asynchronous disposal completes", async () => {
+    let finishDispose: (() => void) | undefined;
+    const owner = new OwnerUnique(
+      "value",
+      () =>
+        new Promise<void>((resolve) => {
+          finishDispose = resolve;
+        }),
+    );
+
+    const disposing = owner.dispose();
+
+    expect(() => owner.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    await vi.waitFor(() => expect(finishDispose).toBeDefined());
+    finishDispose?.();
+    await disposing;
+  });
+
+  it("disposes only once and returns the same result", async () => {
+    const dispose = vi.fn(async () => {});
+    const owner = new OwnerUnique("value", dispose);
+
+    const first = owner.dispose();
+    const second = owner.dispose();
+
+    expect(second).toBe(first);
+    await Promise.all([first, second]);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("moves ownership without disposing the value", async () => {
+    const dispose = vi.fn();
+    const first = new OwnerUnique("value", dispose);
+    const second = OwnerTransferred.from(first);
+
+    expect(dispose).not.toHaveBeenCalled();
+    expect(() => first.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    expect(() => OwnerTransferred.from(first)).toThrow(
+      "Owner has already been moved or disposed",
+    );
+    expect(second.value).toBe("value");
+
+    await first.dispose();
+    expect(dispose).not.toHaveBeenCalled();
+
+    await second.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("caches a disposal failure", async () => {
+    const error = new Error("dispose failed");
+    const dispose = vi.fn(() => {
+      throw error;
+    });
+    const owner = new OwnerUnique("value", dispose);
+
+    const first = owner.dispose();
+    const second = owner.dispose();
+
+    expect(second).toBe(first);
+    await expect(first).rejects.toBe(error);
+    await expect(second).rejects.toBe(error);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/utils/owner/unique.ts
+++ b/packages/core/src/utils/owner/unique.ts
@@ -1,0 +1,30 @@
+import { Owner } from "./owner.js";
+
+/**
+ * An Owner with a single, transferable ownership claim.
+ *
+ * @example
+ * ```ts
+ * const owner = new OwnerUnique(
+ *   new AbortController(),
+ *   (controller) => controller.abort(),
+ * );
+ *
+ * const signal = owner.value.signal;
+ * await owner.dispose();
+ * ```
+ *
+ * @public
+ */
+export class OwnerUnique<T> extends Owner<T> {
+  constructor(
+    protected readonly value_: T,
+    private readonly disposer: (value: T) => PromiseLike<void> | void,
+  ) {
+    super();
+  }
+
+  protected release(value: T) {
+    return this.disposer(value);
+  }
+}

--- a/packages/demo/src/app/connected/(tools)/SSRI/page.tsx
+++ b/packages/demo/src/app/connected/(tools)/SSRI/page.tsx
@@ -136,7 +136,10 @@ export default function SSRI() {
     setMethodResult(undefined);
     setIconDataURL("");
 
-    const testSSRIExecutor = new ssri.ExecutorJsonRpc(SSRIExecutorURL);
+    const executorOwner = ssri.ExecutorJsonRpc.open({
+      urls: [SSRIExecutorURL],
+    });
+    const testSSRIExecutor = executorOwner.value;
 
     let contract: ssri.Trait | undefined;
     try {
@@ -232,7 +235,11 @@ export default function SSRI() {
       setMethodResult(`Error: ${errorMessage}`);
       error(`Error: ${errorMessage}`);
     } finally {
-      setIsLoading(false);
+      try {
+        await executorOwner.dispose();
+      } finally {
+        setIsLoading(false);
+      }
     }
 
     async function callSSRI(

--- a/packages/demo/src/app/layoutProvider.tsx
+++ b/packages/demo/src/app/layoutProvider.tsx
@@ -21,17 +21,6 @@ import {
 import Link from "next/link";
 import { ReactNode, useEffect, useState } from "react";
 
-const clientOptions = [
-  {
-    name: "CKB Testnet",
-    client: new ccc.ClientPublicTestnet(),
-  },
-  {
-    name: "CKB Mainnet",
-    client: new ccc.ClientPublicMainnet(),
-  },
-];
-
 function Links(props: React.ComponentPropsWithoutRef<"div">) {
   const { index } = useGetExplorerLink();
 
@@ -113,8 +102,8 @@ function ClientSwitcher() {
       onClick={() =>
         setClient(
           isTestnet
-            ? new ccc.ClientPublicMainnet()
-            : new ccc.ClientPublicTestnet(),
+            ? ccc.ClientPublicMainnet.open()
+            : ccc.ClientPublicTestnet.open(),
         )
       }
       className="mr-4 flex gap-2"
@@ -244,9 +233,29 @@ function Addresses() {
 }
 
 export function LayoutProvider({ children }: { children: ReactNode }) {
+  const [clientOptions, setClientOptions] =
+    useState<{ name: string; client: ccc.Client }[]>();
+
+  useEffect(() => {
+    const owner = ccc.OwnerAggregated.from([
+      ccc.ClientPublicTestnet.open(),
+      ccc.ClientPublicMainnet.open(),
+    ] as const);
+    const [testnet, mainnet] = owner.value;
+    // The clients must be opened after commit to avoid leaking aborted renders.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setClientOptions([
+      { name: "CKB Testnet", client: testnet },
+      { name: "CKB Mainnet", client: mainnet },
+    ]);
+    return () => void owner.dispose().catch(() => {});
+  }, []);
+
+  if (!clientOptions) return null;
+
   return (
     <ccc.Provider /*
-      defaultClient={new ccc.ClientPublicTestnet()} // Default client used by connector
+      defaultClient={clientOptions[0].client} // Default borrowed client
       connectorProps={{
         style: {
           "--background": "#fff",

--- a/packages/docs/content/docs/concepts/address.mdx
+++ b/packages/docs/content/docs/concepts/address.mdx
@@ -42,7 +42,9 @@ const address = ccc.Address.from({
 ```ts
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicMainnet();
+const clientOwner = ccc.ClientPublicMainnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const address = await ccc.Address.fromString(
   "ckb1qzda0cr08m85hc8jlnfp3sdrlalyatuqvqdveld...",
   client,
@@ -59,10 +61,16 @@ It validates that the address prefix matches the client's network and throws on 
 When you need to handle both networks in the same code path, pass a record of clients:
 
 ```ts
+const clientsOwner = ccc.OwnerAggregated.from([
+  ccc.ClientPublicMainnet.open(),
+  ccc.ClientPublicTestnet.open(),
+] as const);
+const [mainnetClient, testnetClient] = clientsOwner.value;
 const address = await ccc.Address.fromString(someAddress, {
-  ckb: new ccc.ClientPublicMainnet(),
-  ckt: new ccc.ClientPublicTestnet(),
+  ckb: mainnetClient,
+  ckt: testnetClient,
 });
+await clientsOwner.dispose();
 ```
 
 ### Construct an address from a script
@@ -145,7 +153,9 @@ Decoding a short address requires a `Client` to look up the current `codeHash` a
 Read the prefix at runtime from the client:
 
 ```ts
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 console.log(client.addressPrefix); // "ckt"
 ```
 

--- a/packages/docs/content/docs/concepts/address.zh.mdx
+++ b/packages/docs/content/docs/concepts/address.zh.mdx
@@ -42,7 +42,9 @@ const address = ccc.Address.from({
 ```ts
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicMainnet();
+const clientOwner = ccc.ClientPublicMainnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const address = await ccc.Address.fromString(
   "ckb1qzda0cr08m85hc8jlnfp3sdrlalyatuqvqdveld...",
   client,
@@ -59,10 +61,16 @@ console.log(address.prefix);          // "ckb"
 如果同一段代码需要同时处理两个网络，可以传入一个 `client` 对象字典：
 
 ```ts
+const clientsOwner = ccc.OwnerAggregated.from([
+  ccc.ClientPublicMainnet.open(),
+  ccc.ClientPublicTestnet.open(),
+] as const);
+const [mainnetClient, testnetClient] = clientsOwner.value;
 const address = await ccc.Address.fromString(someAddress, {
-  ckb: new ccc.ClientPublicMainnet(),
-  ckt: new ccc.ClientPublicTestnet(),
+  ckb: mainnetClient,
+  ckt: testnetClient,
 });
+await clientsOwner.dispose();
 ```
 
 ### 从脚本构造地址
@@ -145,7 +153,9 @@ CCC 支持四种地址格式，由首字节（format byte）区分。`toString()
 运行时可从 `client` 读取前缀：
 
 ```ts
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 console.log(client.addressPrefix); // "ckt"
 ```
 

--- a/packages/docs/content/docs/concepts/client.mdx
+++ b/packages/docs/content/docs/concepts/client.mdx
@@ -33,14 +33,18 @@ CCC ships with two ready-to-use client implementations:
     ```typescript
     import { ccc } from "@ckb-ccc/ccc";
 
-    const client = new ccc.ClientPublicMainnet();
+    const clientOwner = ccc.ClientPublicMainnet.open();
+    const client = clientOwner.value;
+    // Call `await clientOwner.dispose()` when it is no longer needed.
     ```
   </Tab>
   <Tab value="Testnet">
     ```typescript
     import { ccc } from "@ckb-ccc/ccc";
 
-    const client = new ccc.ClientPublicTestnet();
+    const clientOwner = ccc.ClientPublicTestnet.open();
+    const client = clientOwner.value;
+    // Call `await clientOwner.dispose()` when it is no longer needed.
     ```
   </Tab>
 </Tabs>
@@ -221,7 +225,9 @@ Use `getKnownScript()` to fetch the `codeHash`, `hashType`, and `cellDeps` for a
 ```typescript
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 
 // Resolve to a Script instance directly
 const xudtScript = await ccc.Script.fromKnownScript(
@@ -240,10 +246,12 @@ Every client includes a `ClientCache` instance that stores previously fetched ce
 const cache: ccc.ClientCache = client.cache;
 ```
 
-The default cache is `ClientCacheMemory`, which holds data in process memory. You can supply a custom cache implementation via the constructor:
+The default cache is `ClientCacheMemory`, which holds data in process memory. You can supply a borrowed custom cache implementation when opening a Client:
 
 ```typescript
-const client = new ccc.ClientPublicTestnet({ cache: myCustomCache });
+const clientOwner = ccc.ClientPublicTestnet.open({ cache: myCustomCache });
+const client = clientOwner.value;
+// The Client borrows myCustomCache; disposing the Owner does not dispose it.
 ```
 
 ## Usage Examples
@@ -254,7 +262,9 @@ const client = new ccc.ClientPublicTestnet({ cache: myCustomCache });
 import { ccc } from "@ckb-ccc/ccc";
 
 async function queryChain() {
-  const client = new ccc.ClientPublicTestnet();
+  const clientOwner = ccc.ClientPublicTestnet.open();
+  const client = clientOwner.value;
+  // Call `await clientOwner.dispose()` when it is no longer needed.
 
   // Get the current tip block number
   const tip = await client.getTip();

--- a/packages/docs/content/docs/concepts/client.zh.mdx
+++ b/packages/docs/content/docs/concepts/client.zh.mdx
@@ -33,14 +33,18 @@ CCC 提供两个开箱即用的 `Client` 实现：
     ```typescript
     import { ccc } from "@ckb-ccc/ccc";
 
-    const client = new ccc.ClientPublicMainnet();
+    const clientOwner = ccc.ClientPublicMainnet.open();
+    const client = clientOwner.value;
+    // 不再使用时调用 `await clientOwner.dispose()`。
     ```
   </Tab>
   <Tab value="测试网">
     ```typescript
     import { ccc } from "@ckb-ccc/ccc";
 
-    const client = new ccc.ClientPublicTestnet();
+    const clientOwner = ccc.ClientPublicTestnet.open();
+    const client = clientOwner.value;
+    // 不再使用时调用 `await clientOwner.dispose()`。
     ```
   </Tab>
 </Tabs>
@@ -221,7 +225,9 @@ export enum KnownScript {
 ```typescript
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 
 // 直接构造 Script 实例
 const xudtScript = await ccc.Script.fromKnownScript(
@@ -240,10 +246,12 @@ const xudtScript = await ccc.Script.fromKnownScript(
 const cache: ccc.ClientCache = client.cache;
 ```
 
-默认缓存实现为 `ClientCacheMemory`，数据存储在进程内存中。可通过构造函数传入自定义缓存实现：
+默认缓存实现为 `ClientCacheMemory`，数据存储在进程内存中。打开 Client 时可传入借用的自定义缓存实现：
 
 ```typescript
-const client = new ccc.ClientPublicTestnet({ cache: myCustomCache });
+const clientOwner = ccc.ClientPublicTestnet.open({ cache: myCustomCache });
+const client = clientOwner.value;
+// Client 仅借用 myCustomCache；释放 Owner 不会释放该缓存。
 ```
 
 ## 使用示例
@@ -254,7 +262,9 @@ const client = new ccc.ClientPublicTestnet({ cache: myCustomCache });
 import { ccc } from "@ckb-ccc/ccc";
 
 async function queryChain() {
-  const client = new ccc.ClientPublicTestnet();
+  const clientOwner = ccc.ClientPublicTestnet.open();
+  const client = clientOwner.value;
+  // 不再使用时调用 `await clientOwner.dispose()`。
 
   // 获取当前最新区块高度
   const tip = await client.getTip();

--- a/packages/docs/content/docs/getting-started/installation.mdx
+++ b/packages/docs/content/docs/getting-started/installation.mdx
@@ -98,7 +98,9 @@ pnpm add @ckb-ccc/shell
 ```typescript title="script.ts"
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const signer = new ccc.SignerCkbPrivateKey(client, process.env.PRIVATE_KEY!);
 
 const address = await signer.getRecommendedAddress();
@@ -161,7 +163,9 @@ pnpm add @ckb-ccc/ccc
 ```typescript title="custom-ui.ts"
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const controller = new ccc.SignersController();
 let wallets: ccc.WalletWithSigners[] | undefined;
 

--- a/packages/docs/content/docs/getting-started/installation.mdx
+++ b/packages/docs/content/docs/getting-started/installation.mdx
@@ -132,10 +132,22 @@ pnpm add @ckb-ccc/connector
 
 ```typescript title="main.ts"
 import { ccc } from "@ckb-ccc/connector";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+const connector = document.createElement(
+  "ccc-connector",
+) as ccc.WebComponentConnector;
+connector.client = clientOwner.value;
+connector.addEventListener("select-client", (event) => {
+  connector.client = (event as ccc.SelectClientEvent).client;
+});
+document.getElementById("app")!.append(connector);
+// Dispose clientOwner from your application lifecycle after the connector can
+// no longer use it.
 ```
 
 ```html title="index.html"
-<ccc-connector></ccc-connector>
+<div id="app"></div>
 ```
   </Tab>
 

--- a/packages/docs/content/docs/getting-started/installation.zh.mdx
+++ b/packages/docs/content/docs/getting-started/installation.zh.mdx
@@ -131,10 +131,21 @@ pnpm add @ckb-ccc/connector
 
 ```typescript title="main.ts"
 import { ccc } from "@ckb-ccc/connector";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+const connector = document.createElement(
+  "ccc-connector",
+) as ccc.WebComponentConnector;
+connector.client = clientOwner.value;
+connector.addEventListener("select-client", (event) => {
+  connector.client = (event as ccc.SelectClientEvent).client;
+});
+document.getElementById("app")!.append(connector);
+// 确认 connector 不会再使用该 Client 后，在应用生命周期中释放 clientOwner。
 ```
 
 ```html title="index.html"
-<ccc-connector></ccc-connector>
+<div id="app"></div>
 ```
   </Tab>
 

--- a/packages/docs/content/docs/getting-started/installation.zh.mdx
+++ b/packages/docs/content/docs/getting-started/installation.zh.mdx
@@ -98,7 +98,9 @@ pnpm add @ckb-ccc/shell
 ```typescript title="script.ts"
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const signer = new ccc.SignerCkbPrivateKey(client, process.env.PRIVATE_KEY!);
 
 const address = await signer.getRecommendedAddress();
@@ -160,7 +162,9 @@ pnpm add @ckb-ccc/ccc
 ```typescript title="custom-ui.ts"
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const controller = new ccc.SignersController();
 let wallets: ccc.WalletWithSigners[] | undefined;
 

--- a/packages/docs/content/docs/guides/node-js-backend.mdx
+++ b/packages/docs/content/docs/guides/node-js-backend.mdx
@@ -65,8 +65,8 @@ Use `ClientPublicMainnet` or `ClientPublicTestnet` for zero-config connectivity.
     ```typescript
     import { ccc } from "@ckb-ccc/shell";
 
-    const client = new ccc.ClientPublicMainnet({
-      url: "https://your-ckb-node.example.com/rpc",
+    const clientOwner = ccc.ClientPublicMainnet.open({
+      urls: ["https://your-ckb-node.example.com/rpc"],
     });
     ```
   </Tab>
@@ -196,7 +196,7 @@ Your project is using CommonJS (`require`). Either switch to ESM (`"type": "modu
 The key must be exactly 32 bytes (64 hex characters), without `0x` prefix. Double-check your environment variable.
 
 **`ClientPublicTestnet` connection times out**
-Public nodes may be rate-limited. For production, run your own CKB node and pass its URL to `ClientPublicMainnet({ url: "..." })`.
+Public nodes may be rate-limited. For production, run your own CKB node and pass its endpoint to `ClientPublicMainnet.open({ urls: ["..."] })`.
 
 **I want to use browser-wallet signers (JoyID, MetaMask) on the server**
 Those signers require a browser environment. On the server, use `SignerCkbPrivateKey`. If you need to verify wallet signatures on the server, use `ccc.Signer.verifyMessage()` — see [Sign Messages](/docs/guides/sign-message).

--- a/packages/docs/content/docs/guides/node-js-backend.mdx
+++ b/packages/docs/content/docs/guides/node-js-backend.mdx
@@ -47,7 +47,9 @@ Use `ClientPublicMainnet` or `ClientPublicTestnet` for zero-config connectivity.
     ```typescript
     import { ccc } from "@ckb-ccc/shell";
 
-    const client = new ccc.ClientPublicMainnet();
+    const clientOwner = ccc.ClientPublicMainnet.open();
+    const client = clientOwner.value;
+    // Call `await clientOwner.dispose()` when it is no longer needed.
     // Defaults to wss://mainnet.ckb.dev/ws (Node.js with WebSocket)
     // Falls back to https://mainnet.ckb.dev/ and https://mainnet.ckbapp.dev/
     ```
@@ -57,7 +59,9 @@ Use `ClientPublicMainnet` or `ClientPublicTestnet` for zero-config connectivity.
     ```typescript
     import { ccc } from "@ckb-ccc/shell";
 
-    const client = new ccc.ClientPublicTestnet();
+    const clientOwner = ccc.ClientPublicTestnet.open();
+    const client = clientOwner.value;
+    // Call `await clientOwner.dispose()` when it is no longer needed.
     ```
   </Tab>
 
@@ -68,6 +72,8 @@ Use `ClientPublicMainnet` or `ClientPublicTestnet` for zero-config connectivity.
     const clientOwner = ccc.ClientPublicMainnet.open({
       urls: ["https://your-ckb-node.example.com/rpc"],
     });
+    const client = clientOwner.value;
+    // Call `await clientOwner.dispose()` when it is no longer needed.
     ```
   </Tab>
 </Tabs>
@@ -79,7 +85,9 @@ Use `ClientPublicMainnet` or `ClientPublicTestnet` for zero-config connectivity.
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const signer = new ccc.SignerCkbPrivateKey(
   client,
   process.env.CKB_PRIVATE_KEY!, // 32-byte hex, loaded from environment
@@ -101,7 +109,9 @@ console.log("Address:", address); // "ckt1qz..." (testnet) or "ckb1qz..." (mainn
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicMainnet();
+const clientOwner = ccc.ClientPublicMainnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const signer = new ccc.SignerCkbPrivateKey(client, process.env.CKB_PRIVATE_KEY!);
 await signer.connect();
 
@@ -117,7 +127,9 @@ import { ccc } from "@ckb-ccc/shell";
 
 async function main() {
   // 1. Connect to testnet
-  const client = new ccc.ClientPublicTestnet();
+  const clientOwner = ccc.ClientPublicTestnet.open();
+  const client = clientOwner.value;
+  // Call `await clientOwner.dispose()` when it is no longer needed.
   const signer = new ccc.SignerCkbPrivateKey(client, process.env.CKB_PRIVATE_KEY!);
   await signer.connect();
 

--- a/packages/docs/content/docs/guides/node-js-backend.zh.mdx
+++ b/packages/docs/content/docs/guides/node-js-backend.zh.mdx
@@ -45,7 +45,9 @@ import { ccc } from "@ckb-ccc/shell";
     ```typescript
     import { ccc } from "@ckb-ccc/shell";
 
-    const client = new ccc.ClientPublicMainnet();
+    const clientOwner = ccc.ClientPublicMainnet.open();
+    const client = clientOwner.value;
+    // 不再使用时调用 `await clientOwner.dispose()`。
     // 默认连接 wss://mainnet.ckb.dev/ws（Node.js WebSocket）
     // 降级备用：https://mainnet.ckb.dev/ 和 https://mainnet.ckbapp.dev/
     ```
@@ -55,7 +57,9 @@ import { ccc } from "@ckb-ccc/shell";
     ```typescript
     import { ccc } from "@ckb-ccc/shell";
 
-    const client = new ccc.ClientPublicTestnet();
+    const clientOwner = ccc.ClientPublicTestnet.open();
+    const client = clientOwner.value;
+    // 不再使用时调用 `await clientOwner.dispose()`。
     ```
   </Tab>
 
@@ -66,6 +70,8 @@ import { ccc } from "@ckb-ccc/shell";
     const clientOwner = ccc.ClientPublicMainnet.open({
       urls: ["https://your-ckb-node.example.com/rpc"],
     });
+    const client = clientOwner.value;
+    // 不再使用时调用 `await clientOwner.dispose()`。
     ```
   </Tab>
 </Tabs>
@@ -77,7 +83,9 @@ import { ccc } from "@ckb-ccc/shell";
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const signer = new ccc.SignerCkbPrivateKey(
   client,
   process.env.CKB_PRIVATE_KEY!, // 32 字节十六进制，从环境变量读取
@@ -99,7 +107,9 @@ console.log("Address:", address); // "ckt1qz..."（测试网）或 "ckb1qz..."�
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicMainnet();
+const clientOwner = ccc.ClientPublicMainnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const signer = new ccc.SignerCkbPrivateKey(client, process.env.CKB_PRIVATE_KEY!);
 await signer.connect();
 
@@ -115,7 +125,9 @@ import { ccc } from "@ckb-ccc/shell";
 
 async function main() {
   // 1. 连接测试网
-  const client = new ccc.ClientPublicTestnet();
+  const clientOwner = ccc.ClientPublicTestnet.open();
+  const client = clientOwner.value;
+  // 不再使用时调用 `await clientOwner.dispose()`。
   const signer = new ccc.SignerCkbPrivateKey(client, process.env.CKB_PRIVATE_KEY!);
   await signer.connect();
 

--- a/packages/docs/content/docs/guides/node-js-backend.zh.mdx
+++ b/packages/docs/content/docs/guides/node-js-backend.zh.mdx
@@ -63,8 +63,8 @@ import { ccc } from "@ckb-ccc/shell";
     ```typescript
     import { ccc } from "@ckb-ccc/shell";
 
-    const client = new ccc.ClientPublicMainnet({
-      url: "https://your-ckb-node.example.com/rpc",
+    const clientOwner = ccc.ClientPublicMainnet.open({
+      urls: ["https://your-ckb-node.example.com/rpc"],
     });
     ```
   </Tab>
@@ -194,7 +194,7 @@ import { cccA } from "@ckb-ccc/shell/advanced";
 私钥须为恰好 32 字节（64 个十六进制字符），不含 `0x` 前缀。请检查环境变量的值。
 
 **`ClientPublicTestnet` 连接超时**
-公共节点可能有频率限制。生产环境建议自建 CKB 节点，并将其 URL 传入 `ClientPublicMainnet({ url: "..." })`。
+公共节点可能有频率限制。生产环境建议自建 CKB 节点，并将节点地址传入 `ClientPublicMainnet.open({ urls: ["..."] })`。
 
 **需要在服务端使用浏览器钱包 Signer（JoyID、MetaMask）**
 此类 Signer 依赖浏览器环境，服务端请使用 `SignerCkbPrivateKey`。如需在服务端验证钱包签名，使用 `ccc.Signer.verifyMessage()`——参见[消息签名](/docs/guides/sign-message)。

--- a/packages/docs/content/docs/packages/core-packages/ccc.mdx
+++ b/packages/docs/content/docs/packages/core-packages/ccc.mdx
@@ -62,7 +62,9 @@ It also adds one package-level export:
 ```typescript
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 
 // Discover all wallets available in the current browser environment
 const controller = new ccc.SignersController(client);

--- a/packages/docs/content/docs/packages/core-packages/ccc.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/ccc.zh.mdx
@@ -62,7 +62,9 @@ import { PackageBadges } from '@/components/package-badges';
 ```typescript
 import { ccc } from "@ckb-ccc/ccc";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 
 // 自动发现当前浏览器环境中的所有钱包
 const controller = new ccc.SignersController(client);

--- a/packages/docs/content/docs/packages/core-packages/connector-react.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector-react.mdx
@@ -87,19 +87,39 @@ import { PackageBadges } from '@/components/package-badges';
 ## Provider props
 
 ```tsx
-<ccc.Provider
-  hideMark={false}
-  name="My App"
-  icon="https://example.com/icon.png"
-  signerFilter={async (signerInfo, wallet) => true}
-  defaultClient={new ccc.ClientPublicTestnet()}
-  clientOptions={[
-    { name: "Testnet", client: new ccc.ClientPublicTestnet() },
-    { name: "Mainnet", client: new ccc.ClientPublicMainnet() },
-  ]}
->
-  {children}
-</ccc.Provider>
+function CccProvider({ children }: { children: React.ReactNode }) {
+  const [clientOptions, setClientOptions] =
+    useState<{ name: string; client: ccc.Client }[]>();
+
+  useEffect(() => {
+    const owner = ccc.OwnerAggregated.from([
+      ccc.ClientPublicTestnet.open(),
+      ccc.ClientPublicMainnet.open(),
+    ] as const);
+    const [testnet, mainnet] = owner.value;
+    // The clients must be opened after commit to avoid leaking aborted renders.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setClientOptions([
+      { name: "Testnet", client: testnet },
+      { name: "Mainnet", client: mainnet },
+    ]);
+    return () => void owner.dispose().catch(() => {});
+  }, []);
+
+  if (!clientOptions) return null;
+
+  return (
+    <ccc.Provider
+      hideMark={false}
+      name="My App"
+      icon="https://example.com/icon.png"
+      signerFilter={async (signerInfo, wallet) => true}
+      clientOptions={clientOptions}
+    >
+      {children}
+    </ccc.Provider>
+  );
+}
 ```
 
 | Prop                | Type                                       | Description                                        |
@@ -111,8 +131,8 @@ import { PackageBadges } from '@/components/package-badges';
 | `icon`              | `string?`                                  | App icon URL shown in the wallet picker            |
 | `signerFilter`      | `(signerInfo, wallet) => Promise<boolean>` | Filter which wallet/signer combinations appear     |
 | `signersController` | `ccc.SignersController?`                   | Custom signers controller (advanced)               |
-| `defaultClient`     | `ccc.Client?`                              | The initial network client                         |
-| `clientOptions`     | `{ icon?, client, name }[]?`               | Network options to display in the connector        |
+| `defaultClient`     | `ccc.Client?`                              | Borrowed initial client; takes precedence over `clientOptions[0]` |
+| `clientOptions`     | `{ icon?, client, name }[]?`               | Borrowed network options; the first is the default when `defaultClient` is omitted |
 
 ## Styling the connector
 
@@ -150,7 +170,7 @@ const {
   open,        // () => void — open the wallet picker
   close,       // () => void — close the wallet picker
   disconnect,  // () => void — disconnect the current wallet
-  setClient,   // (client: ccc.Client) => void — switch network
+  setClient,   // (owner: ccc.Owner<ccc.Client>) => void — transfer and switch client
   client,      // ccc.Client — current network client
   wallet,      // ccc.Wallet | undefined — connected wallet
   signerInfo,  // ccc.SignerInfo | undefined — connected signer
@@ -158,6 +178,11 @@ const {
 ```
 
 The hook throws if called outside a `<ccc.Provider>` tree.
+
+Clients passed through `defaultClient` or `clientOptions` remain owned by the
+caller. `setClient(owner)` transfers ownership to the Provider, which disposes
+the owner when it is replaced or unmounted. Passing a bare `Client` to
+`setClient` remains supported for compatibility, but is deprecated.
 
 ## Full example
 
@@ -169,10 +194,7 @@ import { useState, useEffect } from "react";
 
 function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <ccc.Provider
-      name="My CKB App"
-      defaultClient={new ccc.ClientPublicTestnet()}
-    >
+    <ccc.Provider name="My CKB App">
       <Header />
       {children}
     </ccc.Provider>

--- a/packages/docs/content/docs/packages/core-packages/connector-react.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector-react.mdx
@@ -181,8 +181,31 @@ The hook throws if called outside a `<ccc.Provider>` tree.
 
 Clients passed through `defaultClient` or `clientOptions` remain owned by the
 caller. `setClient(owner)` transfers ownership to the Provider, which disposes
-the owner when it is replaced or unmounted. Passing a bare `Client` to
+the owner on the next `setClient` call or when the Provider unmounts. Passing a bare `Client` to
 `setClient` remains supported for compatibility, but is deprecated.
+
+## `useBorrowedOrOwned()` hook
+
+Use this hook for resources that may be borrowed from a parent but need an
+internally owned fallback when the parent does not provide one:
+
+```tsx
+function openTestnetClient() {
+  return ccc.ClientPublicTestnet.open();
+}
+
+function ClientConsumer({ client: borrowed }: { client?: ccc.Client }) {
+  const client = ccc.useBorrowedOrOwned(borrowed, openTestnetClient);
+  if (!client) return null; // The fallback opens after the component commits.
+
+  return <App client={client} />;
+}
+```
+
+The hook never disposes a borrowed value. Its fallback Owner is independent of
+the borrowed value and remains available for reuse. It is reopened only when
+the `open` function changes and is disposed when replaced or when the component
+unmounts. Keep `open` referentially stable.
 
 ## Full example
 

--- a/packages/docs/content/docs/packages/core-packages/connector-react.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector-react.zh.mdx
@@ -176,8 +176,30 @@ const {
 在 `<ccc.Provider>` 树之外调用此 Hook 会抛出错误。
 
 通过 `defaultClient` 或 `clientOptions` 传入的客户端仍由调用方持有并负责清理。
-调用 `setClient(owner)` 会将所有权转移给 Provider；该 owner 会在被替换或 Provider
-卸载时清理。为兼容旧代码，`setClient` 仍可接收裸 `Client`，但该用法已弃用。
+调用 `setClient(owner)` 会将所有权转移给 Provider；该 owner 会在下次调用
+`setClient` 或 Provider 卸载时清理。为兼容旧代码，`setClient` 仍可接收裸
+`Client`，但该用法已弃用。
+
+## `useBorrowedOrOwned()` Hook
+
+当资源可能从上层借用、而上层未提供时又需要创建内部 fallback，可以使用此 Hook：
+
+```tsx
+function openTestnetClient() {
+  return ccc.ClientPublicTestnet.open();
+}
+
+function ClientConsumer({ client: borrowed }: { client?: ccc.Client }) {
+  const client = ccc.useBorrowedOrOwned(borrowed, openTestnetClient);
+  if (!client) return null; // fallback 会在组件 commit 后创建。
+
+  return <App client={client} />;
+}
+```
+
+Hook 不会释放借用值。fallback Owner 与借用值相互独立，可以持续复用；只有
+`open` 函数变化时才会重新创建，并在被替换或组件卸载时释放。应保持 `open`
+的引用稳定。
 
 ## 完整示例
 

--- a/packages/docs/content/docs/packages/core-packages/connector-react.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector-react.zh.mdx
@@ -84,19 +84,39 @@ import { PackageBadges } from '@/components/package-badges';
 ## Provider 属性
 
 ```tsx
-<ccc.Provider
-  hideMark={false}
-  name="My App"
-  icon="https://example.com/icon.png"
-  signerFilter={async (signerInfo, wallet) => true}
-  defaultClient={new ccc.ClientPublicTestnet()}
-  clientOptions={[
-    { name: "Testnet", client: new ccc.ClientPublicTestnet() },
-    { name: "Mainnet", client: new ccc.ClientPublicMainnet() },
-  ]}
->
-  {children}
-</ccc.Provider>
+function CccProvider({ children }: { children: React.ReactNode }) {
+  const [clientOptions, setClientOptions] =
+    useState<{ name: string; client: ccc.Client }[]>();
+
+  useEffect(() => {
+    const owner = ccc.OwnerAggregated.from([
+      ccc.ClientPublicTestnet.open(),
+      ccc.ClientPublicMainnet.open(),
+    ] as const);
+    const [testnet, mainnet] = owner.value;
+    // Client 必须在 commit 后打开，避免 aborted render 泄漏资源。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setClientOptions([
+      { name: "Testnet", client: testnet },
+      { name: "Mainnet", client: mainnet },
+    ]);
+    return () => void owner.dispose().catch(() => {});
+  }, []);
+
+  if (!clientOptions) return null;
+
+  return (
+    <ccc.Provider
+      hideMark={false}
+      name="My App"
+      icon="https://example.com/icon.png"
+      signerFilter={async (signerInfo, wallet) => true}
+      clientOptions={clientOptions}
+    >
+      {children}
+    </ccc.Provider>
+  );
+}
 ```
 
 | 属性名               | 类型                                       | 说明                                               |
@@ -108,8 +128,8 @@ import { PackageBadges } from '@/components/package-badges';
 | `icon`              | `string?`                                  | 显示在钱包选择界面中的应用图标 URL                 |
 | `signerFilter`      | `(signerInfo, wallet) => Promise<boolean>` | 筛选在界面中显示的钱包与 `signer` 组合             |
 | `signersController` | `ccc.SignersController?`                   | 自定义 Signers Controller（高级用法）              |
-| `defaultClient`     | `ccc.Client?`                              | 初始网络客户端                                     |
-| `clientOptions`     | `{ icon?, client, name }[]?`               | 在连接器中展示的可选网络列表                       |
+| `defaultClient`     | `ccc.Client?`                              | 借用的初始客户端；优先于 `clientOptions[0]`         |
+| `clientOptions`     | `{ icon?, client, name }[]?`               | 借用的网络选项；未传 `defaultClient` 时首项为默认值 |
 
 ## 调整 Connector 样式
 
@@ -146,7 +166,7 @@ const {
   open,        // () => void——打开钱包选择界面
   close,       // () => void——关闭钱包选择界面
   disconnect,  // () => void——断开当前钱包连接
-  setClient,   // (client: ccc.Client) => void——切换网络
+  setClient,   // (owner: ccc.Owner<ccc.Client>) => void——转移所有权并切换客户端
   client,      // ccc.Client——当前网络客户端
   wallet,      // ccc.Wallet | undefined——已连接的钱包
   signerInfo,  // ccc.SignerInfo | undefined——已连接的 signer
@@ -154,6 +174,10 @@ const {
 ```
 
 在 `<ccc.Provider>` 树之外调用此 Hook 会抛出错误。
+
+通过 `defaultClient` 或 `clientOptions` 传入的客户端仍由调用方持有并负责清理。
+调用 `setClient(owner)` 会将所有权转移给 Provider；该 owner 会在被替换或 Provider
+卸载时清理。为兼容旧代码，`setClient` 仍可接收裸 `Client`，但该用法已弃用。
 
 ## 完整示例
 
@@ -165,10 +189,7 @@ import { useState, useEffect } from "react";
 
 function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <ccc.Provider
-      name="My CKB App"
-      defaultClient={new ccc.ClientPublicTestnet()}
-    >
+    <ccc.Provider name="My CKB App">
       <Header />
       {children}
     </ccc.Provider>

--- a/packages/docs/content/docs/packages/core-packages/connector.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector.mdx
@@ -43,13 +43,22 @@ import { ccc } from "@ckb-ccc/connector";
 // The connector element
 const connector: ccc.WebComponentConnector;
 
-connector.client;       // current ccc.Client
+connector.client;       // required borrowed ccc.Client
 connector.wallet;       // connected ccc.Wallet | undefined
 connector.signer;       // ccc.SignerInfo | undefined
 
 connector.disconnect(); // disconnect the current wallet
-connector.setClient(newClient); // switch networks
+connector.addEventListener("select-client", (event) => {
+  connector.client = (event as ccc.SelectClientEvent).client;
+});
 ```
+
+The Web Component requires and only borrows its `client`; it never creates or
+disposes one. Assign a client before adding the element to the document, keep
+its owner alive for as long as the element may use it, and dispose the owner
+from your application lifecycle. Network and fee-rate selections emit a
+composed, bubbling `select-client` event; the application decides whether to
+feed its candidate Client back through the `client` property.
 
 ## Select a transaction fee rate
 
@@ -69,7 +78,16 @@ only.
     <script type="module">
       import { ccc } from "https://esm.sh/@ckb-ccc/connector";
 
-      const connector = document.getElementById("ccc-connector");
+      const connector = document.createElement("ccc-connector");
+      const clientOwner = ccc.ClientPublicTestnet.open();
+      connector.client = clientOwner.value;
+      connector.style.cssText = "display: none; z-index: 999;";
+
+      window.addEventListener(
+        "pagehide",
+        () => void clientOwner.dispose(),
+        { once: true },
+      );
 
       document.getElementById("open-btn").addEventListener("click", () => {
         connector.style.display = "";
@@ -79,6 +97,10 @@ only.
         connector.style.display = "none";
       });
 
+      connector.addEventListener("select-client", (event) => {
+        connector.client = event.client;
+      });
+
       connector.addEventListener("willUpdate", () => {
         if (connector.signer) {
           connector.signer.signer.getRecommendedAddress().then((addr) => {
@@ -86,16 +108,15 @@ only.
           });
         }
       });
+
+      // `client` must be assigned before the element is connected.
+      document.body.append(connector);
     </script>
   </head>
   <body>
     <button id="open-btn">Connect Wallet</button>
     <p id="address"></p>
 
-    <ccc-connector
-      id="ccc-connector"
-      style="display: none; z-index: 999;"
-    ></ccc-connector>
   </body>
 </html>
 ```
@@ -106,7 +127,11 @@ only.
 import { ccc } from "@ckb-ccc/connector";
 
 // The custom element is auto-registered when you import the package.
-const connector = document.querySelector("ccc-connector") as ccc.WebComponentConnector;
+const connector = document.createElement(
+  "ccc-connector",
+) as ccc.WebComponentConnector;
+const clientOwner = ccc.ClientPublicTestnet.open();
+connector.client = clientOwner.value; // The Connector borrows it.
 
 // Show the wallet picker
 connector.style.display = "";
@@ -116,18 +141,21 @@ connector.addEventListener("close", () => {
   connector.style.display = "none";
 });
 
+// The Connector requests changes; the application controls the Client.
+connector.addEventListener("select-client", (event) => {
+  connector.client = (event as ccc.SelectClientEvent).client;
+});
+
 connector.addEventListener("willUpdate", () => {
   console.log("Connected wallet:", connector.wallet?.name);
   console.log("Signer:", connector.signer);
 });
 
-// Switch to mainnet
-const mainnetClientOwner = ccc.ClientPublicMainnet.open();
-connector.setClient(mainnetClientOwner.value); // The Connector borrows it.
+// `client` must be assigned before the element is connected.
+document.body.append(connector);
 
-// Later, after the Connector has switched away from this Client or has been
-// removed from the document, the caller can release it:
-// await mainnetClientOwner.dispose();
+// Once the Connector can no longer use this Client, the caller releases it:
+// await clientOwner.dispose();
 ```
 
 ## Styling with CSS custom properties

--- a/packages/docs/content/docs/packages/core-packages/connector.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector.mdx
@@ -122,7 +122,12 @@ connector.addEventListener("willUpdate", () => {
 });
 
 // Switch to mainnet
-connector.setClient(new ccc.ClientPublicMainnet());
+const mainnetClientOwner = ccc.ClientPublicMainnet.open();
+connector.setClient(mainnetClientOwner.value); // The Connector borrows it.
+
+// Later, after the Connector has switched away from this Client or has been
+// removed from the document, the caller can release it:
+// await mainnetClientOwner.dispose();
 ```
 
 ## Styling with CSS custom properties

--- a/packages/docs/content/docs/packages/core-packages/connector.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector.zh.mdx
@@ -43,13 +43,20 @@ import { ccc } from "@ckb-ccc/connector";
 // connector 元素
 const connector: ccc.WebComponentConnector;
 
-connector.client;       // 当前 ccc.Client
+connector.client;       // 必填、借用的 ccc.Client
 connector.wallet;       // 已连接的 ccc.Wallet | undefined
 connector.signer;       // ccc.SignerInfo | undefined
 
 connector.disconnect(); // 断开当前钱包连接
-connector.setClient(newClient); // 切换网络
+connector.addEventListener("select-client", (event) => {
+  connector.client = (event as ccc.SelectClientEvent).client;
+});
 ```
+
+Web Component 要求传入 `client` 且只借用它，不会创建或释放 Client。必须在元素
+加入文档前完成赋值；只要元素仍可能使用该 Client，就应保持其 owner 存活，并由
+应用生命周期负责释放 owner。网络和 fee-rate 选择都会抛出可穿透 Shadow DOM、
+可冒泡的 `select-client` 事件；应用决定是否将候选 Client 写回 `client` 属性。
 
 ## 选择交易费率
 
@@ -67,7 +74,16 @@ connector.setClient(newClient); // 切换网络
     <script type="module">
       import { ccc } from "https://esm.sh/@ckb-ccc/connector";
 
-      const connector = document.getElementById("ccc-connector");
+      const connector = document.createElement("ccc-connector");
+      const clientOwner = ccc.ClientPublicTestnet.open();
+      connector.client = clientOwner.value;
+      connector.style.cssText = "display: none; z-index: 999;";
+
+      window.addEventListener(
+        "pagehide",
+        () => void clientOwner.dispose(),
+        { once: true },
+      );
 
       document.getElementById("open-btn").addEventListener("click", () => {
         connector.style.display = "";
@@ -77,6 +93,10 @@ connector.setClient(newClient); // 切换网络
         connector.style.display = "none";
       });
 
+      connector.addEventListener("select-client", (event) => {
+        connector.client = event.client;
+      });
+
       connector.addEventListener("willUpdate", () => {
         if (connector.signer) {
           connector.signer.signer.getRecommendedAddress().then((addr) => {
@@ -84,16 +104,15 @@ connector.setClient(newClient); // 切换网络
           });
         }
       });
+
+      // `client` 必须在元素连接到文档前赋值。
+      document.body.append(connector);
     </script>
   </head>
   <body>
     <button id="open-btn">连接钱包</button>
     <p id="address"></p>
 
-    <ccc-connector
-      id="ccc-connector"
-      style="display: none; z-index: 999;"
-    ></ccc-connector>
   </body>
 </html>
 ```
@@ -104,7 +123,11 @@ connector.setClient(newClient); // 切换网络
 import { ccc } from "@ckb-ccc/connector";
 
 // 导入本包后，自定义元素会自动注册。
-const connector = document.querySelector("ccc-connector") as ccc.WebComponentConnector;
+const connector = document.createElement(
+  "ccc-connector",
+) as ccc.WebComponentConnector;
+const clientOwner = ccc.ClientPublicTestnet.open();
+connector.client = clientOwner.value; // Connector 仅借用该 Client。
 
 // 显示钱包选择界面
 connector.style.display = "";
@@ -114,18 +137,21 @@ connector.addEventListener("close", () => {
   connector.style.display = "none";
 });
 
+// Connector 只请求变更；Client 由应用控制。
+connector.addEventListener("select-client", (event) => {
+  connector.client = (event as ccc.SelectClientEvent).client;
+});
+
 connector.addEventListener("willUpdate", () => {
   console.log("已连接钱包：", connector.wallet?.name);
   console.log("Signer：", connector.signer);
 });
 
-// 切换至主网
-const mainnetClientOwner = ccc.ClientPublicMainnet.open();
-connector.setClient(mainnetClientOwner.value); // Connector 仅借用该 Client。
+// `client` 必须在元素连接到文档前赋值。
+document.body.append(connector);
 
-// 后续确认 Connector 已切换到其它 Client 或已从文档中移除后，
-// 再由调用方释放：
-// await mainnetClientOwner.dispose();
+// 确认 Connector 不会再使用该 Client 后，由调用方释放：
+// await clientOwner.dispose();
 ```
 
 ## 使用 CSS 自定义属性调整样式

--- a/packages/docs/content/docs/packages/core-packages/connector.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/connector.zh.mdx
@@ -120,7 +120,12 @@ connector.addEventListener("willUpdate", () => {
 });
 
 // 切换至主网
-connector.setClient(new ccc.ClientPublicMainnet());
+const mainnetClientOwner = ccc.ClientPublicMainnet.open();
+connector.setClient(mainnetClientOwner.value); // Connector 仅借用该 Client。
+
+// 后续确认 Connector 已切换到其它 Client 或已从文档中移除后，
+// 再由调用方释放：
+// await mainnetClientOwner.dispose();
 ```
 
 ## 使用 CSS 自定义属性调整样式

--- a/packages/docs/content/docs/packages/core-packages/core.mdx
+++ b/packages/docs/content/docs/packages/core-packages/core.mdx
@@ -139,7 +139,12 @@ const client = new ccc.ClientPublicTestnet();
 const client = new ccc.ClientPublicMainnet();
 
 // Connect to a custom node
-const client = new ccc.ClientPublicTestnet("https://my-node.example.com/rpc");
+const customClientOwner = ccc.ClientPublicTestnet.open({
+  urls: ["https://my-node.example.com/rpc"],
+});
+const customClient = customClientOwner.value;
+
+// Dispose each Owner when its Client is no longer needed.
 ```
 
 ## Key functions

--- a/packages/docs/content/docs/packages/core-packages/core.mdx
+++ b/packages/docs/content/docs/packages/core-packages/core.mdx
@@ -133,10 +133,12 @@ abstract class Signer {
 
 ```typescript
 // Connect to public testnet
-const client = new ccc.ClientPublicTestnet();
+const testnetClientOwner = ccc.ClientPublicTestnet.open();
+const testnetClient = testnetClientOwner.value;
 
 // Connect to public mainnet
-const client = new ccc.ClientPublicMainnet();
+const mainnetClientOwner = ccc.ClientPublicMainnet.open();
+const mainnetClient = mainnetClientOwner.value;
 
 // Connect to a custom node
 const customClientOwner = ccc.ClientPublicTestnet.open({

--- a/packages/docs/content/docs/packages/core-packages/core.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/core.zh.mdx
@@ -132,10 +132,12 @@ abstract class Signer {
 
 ```typescript
 // 连接公共测试网
-const client = new ccc.ClientPublicTestnet();
+const testnetClientOwner = ccc.ClientPublicTestnet.open();
+const testnetClient = testnetClientOwner.value;
 
 // 连接公共主网
-const client = new ccc.ClientPublicMainnet();
+const mainnetClientOwner = ccc.ClientPublicMainnet.open();
+const mainnetClient = mainnetClientOwner.value;
 
 // 连接自定义节点
 const customClientOwner = ccc.ClientPublicTestnet.open({

--- a/packages/docs/content/docs/packages/core-packages/core.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/core.zh.mdx
@@ -138,7 +138,12 @@ const client = new ccc.ClientPublicTestnet();
 const client = new ccc.ClientPublicMainnet();
 
 // 连接自定义节点
-const client = new ccc.ClientPublicTestnet("https://my-node.example.com/rpc");
+const customClientOwner = ccc.ClientPublicTestnet.open({
+  urls: ["https://my-node.example.com/rpc"],
+});
+const customClient = customClientOwner.value;
+
+// 不再使用各个 Client 时，释放对应的 Owner。
 ```
 
 ## 核心函数

--- a/packages/docs/content/docs/packages/core-packages/shell.mdx
+++ b/packages/docs/content/docs/packages/core-packages/shell.mdx
@@ -77,7 +77,12 @@ const client = new ccc.ClientPublicTestnet();
 const client = new ccc.ClientPublicMainnet();
 
 // Custom node URL
-const client = new ccc.ClientPublicTestnet("http://localhost:8114");
+const customClientOwner = ccc.ClientPublicTestnet.open({
+  urls: ["http://localhost:8114"],
+});
+const customClient = customClientOwner.value;
+
+// Dispose each Owner when its Client is no longer needed.
 ```
 
 ### Sign transactions with a private key

--- a/packages/docs/content/docs/packages/core-packages/shell.mdx
+++ b/packages/docs/content/docs/packages/core-packages/shell.mdx
@@ -71,10 +71,12 @@ import { ccc } from "@ckb-ccc/shell";
 import { ccc } from "@ckb-ccc/shell";
 
 // Public testnet RPC
-const client = new ccc.ClientPublicTestnet();
+const testnetClientOwner = ccc.ClientPublicTestnet.open();
+const testnetClient = testnetClientOwner.value;
 
 // Public mainnet RPC
-const client = new ccc.ClientPublicMainnet();
+const mainnetClientOwner = ccc.ClientPublicMainnet.open();
+const mainnetClient = mainnetClientOwner.value;
 
 // Custom node URL
 const customClientOwner = ccc.ClientPublicTestnet.open({
@@ -90,7 +92,9 @@ const customClient = customClientOwner.value;
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const signer = new ccc.SignerCkbPrivateKey(
   client,
   "0xYOUR_PRIVATE_KEY_HEX",
@@ -105,7 +109,9 @@ console.log("Address:", myAddress);
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const signer = new ccc.SignerCkbPrivateKey(client, "0x...");
 
 const { script: toLock } = await ccc.Address.fromString(
@@ -129,7 +135,9 @@ console.log("Sent:", txHash);
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 
 for await (const cell of client.findCells({
   script: { codeHash: "0x...", hashType: "type", args: "0x" },

--- a/packages/docs/content/docs/packages/core-packages/shell.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/shell.zh.mdx
@@ -77,7 +77,12 @@ const client = new ccc.ClientPublicTestnet();
 const client = new ccc.ClientPublicMainnet();
 
 // 自定义节点
-const client = new ccc.ClientPublicTestnet("http://localhost:8114");
+const customClientOwner = ccc.ClientPublicTestnet.open({
+  urls: ["http://localhost:8114"],
+});
+const customClient = customClientOwner.value;
+
+// 不再使用各个 Client 时，释放对应的 Owner。
 ```
 
 ### 使用私钥签署交易

--- a/packages/docs/content/docs/packages/core-packages/shell.zh.mdx
+++ b/packages/docs/content/docs/packages/core-packages/shell.zh.mdx
@@ -71,10 +71,12 @@ import { ccc } from "@ckb-ccc/shell";
 import { ccc } from "@ckb-ccc/shell";
 
 // 公共测试网
-const client = new ccc.ClientPublicTestnet();
+const testnetClientOwner = ccc.ClientPublicTestnet.open();
+const testnetClient = testnetClientOwner.value;
 
 // 公共主网
-const client = new ccc.ClientPublicMainnet();
+const mainnetClientOwner = ccc.ClientPublicMainnet.open();
+const mainnetClient = mainnetClientOwner.value;
 
 // 自定义节点
 const customClientOwner = ccc.ClientPublicTestnet.open({
@@ -90,7 +92,9 @@ const customClient = customClientOwner.value;
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const signer = new ccc.SignerCkbPrivateKey(
   client,
   "0xYOUR_PRIVATE_KEY_HEX",
@@ -105,7 +109,9 @@ console.log("Address:", myAddress);
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const signer = new ccc.SignerCkbPrivateKey(client, "0x...");
 
 const { script: toLock } = await ccc.Address.fromString(
@@ -129,7 +135,9 @@ console.log("Sent:", txHash);
 ```typescript
 import { ccc } from "@ckb-ccc/shell";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 
 for await (const cell of client.findCells({
   script: { codeHash: "0x...", hashType: "type", args: "0x" },

--- a/packages/docs/content/docs/packages/protocol-sdks/ssri.mdx
+++ b/packages/docs/content/docs/packages/protocol-sdks/ssri.mdx
@@ -103,8 +103,18 @@ trait.tryRun(call): Promise<ExecutorResponse<T | undefined>>
 Connects to an SSRI server over HTTP JSON-RPC:
 
 ```typescript
-const executor = new ssri.ExecutorJsonRpc("https://your-ssri-server.example.com");
+const executorOwner = ssri.ExecutorJsonRpc.open({
+  urls: ["https://your-ssri-server.example.com"],
+});
+const executor = executorOwner.value;
+
+// Release the Executor and its Transport when they are no longer needed.
+await executorOwner.dispose();
 ```
+
+Use `ExecutorJsonRpc.new({ transport })` instead when borrowing an existing
+JSON-RPC Transport. The caller remains responsible for that Transport's
+lifecycle.
 
 ### `ExecutorResponse<T>`
 
@@ -124,20 +134,27 @@ response.map(fn);  // transform the result
 import { ssri } from "@ckb-ccc/ssri";
 import { ccc } from "@ckb-ccc/core";
 
-const executor = new ssri.ExecutorJsonRpc("https://ssri.example.com");
+const executorOwner = ssri.ExecutorJsonRpc.open({
+  urls: ["https://ssri.example.com"],
+});
+const executor = executorOwner.value;
 
 const trait = new ssri.Trait(
   { txHash: "0x...", index: 0 }, // code OutPoint
   executor,
 );
 
-// Check the SSRI version
-const { res: version, cellDeps } = await trait.version();
-console.log("Version:", version);
+try {
+  // Check the SSRI version
+  const { res: version, cellDeps } = await trait.version();
+  console.log("Version:", version);
 
-// List available methods
-const { res: methods } = await trait.getMethods();
-console.log("Methods:", methods);
+  // List available methods
+  const { res: methods } = await trait.getMethods();
+  console.log("Methods:", methods);
+} finally {
+  await executorOwner.dispose();
+}
 ```
 
 ## Execution contexts

--- a/packages/docs/content/docs/packages/protocol-sdks/ssri.zh.mdx
+++ b/packages/docs/content/docs/packages/protocol-sdks/ssri.zh.mdx
@@ -103,8 +103,17 @@ trait.tryRun(call): Promise<ExecutorResponse<T | undefined>>
 通过 HTTP JSON-RPC 连接 SSRI 服务器：
 
 ```typescript
-const executor = new ssri.ExecutorJsonRpc("https://your-ssri-server.example.com");
+const executorOwner = ssri.ExecutorJsonRpc.open({
+  urls: ["https://your-ssri-server.example.com"],
+});
+const executor = executorOwner.value;
+
+// 不再使用时释放 Executor 及其 Transport。
+await executorOwner.dispose();
 ```
+
+如果需要借用已有的 JSON-RPC Transport，请改用
+`ExecutorJsonRpc.new({ transport })`。Transport 的生命周期仍由调用方负责。
 
 ### `ExecutorResponse<T>`
 
@@ -124,20 +133,27 @@ response.map(fn);  // 转换结果
 import { ssri } from "@ckb-ccc/ssri";
 import { ccc } from "@ckb-ccc/core";
 
-const executor = new ssri.ExecutorJsonRpc("https://ssri.example.com");
+const executorOwner = ssri.ExecutorJsonRpc.open({
+  urls: ["https://ssri.example.com"],
+});
+const executor = executorOwner.value;
 
 const trait = new ssri.Trait(
   { txHash: "0x...", index: 0 }, // 代码 OutPoint
   executor,
 );
 
-// 查询 SSRI 版本
-const { res: version, cellDeps } = await trait.version();
-console.log("Version:", version);
+try {
+  // 查询 SSRI 版本
+  const { res: version, cellDeps } = await trait.version();
+  console.log("Version:", version);
 
-// 列出可用方法
-const { res: methods } = await trait.getMethods();
-console.log("Methods:", methods);
+  // 列出可用方法
+  const { res: methods } = await trait.getMethods();
+  console.log("Methods:", methods);
+} finally {
+  await executorOwner.dispose();
+}
 ```
 
 ## 执行上下文

--- a/packages/docs/content/docs/packages/wallet-integrations/joy-id.mdx
+++ b/packages/docs/content/docs/packages/wallet-integrations/joy-id.mdx
@@ -364,7 +364,9 @@ When the user opens the wallet selector, JoyID appears as an option. No addition
 import { ccc } from "@ckb-ccc/core";
 import { getJoyIdSigners } from "@ckb-ccc/joy-id";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 
 const signers = getJoyIdSigners(
   client,
@@ -387,7 +389,9 @@ console.log("CKB Address:", address);
 import { ccc } from "@ckb-ccc/core";
 import { CkbSigner } from "@ckb-ccc/joy-id";
 
-const client = new ccc.ClientPublicMainnet();
+const clientOwner = ccc.ClientPublicMainnet.open();
+const client = clientOwner.value;
+// Call `await clientOwner.dispose()` when it is no longer needed.
 const signer = new CkbSigner(client, "My DApp", "https://my-dapp.com/icon.png");
 
 await signer.connect();

--- a/packages/docs/content/docs/packages/wallet-integrations/joy-id.zh.mdx
+++ b/packages/docs/content/docs/packages/wallet-integrations/joy-id.zh.mdx
@@ -355,7 +355,9 @@ export default function App({ children }) {
 import { ccc } from "@ckb-ccc/core";
 import { getJoyIdSigners } from "@ckb-ccc/joy-id";
 
-const client = new ccc.ClientPublicTestnet();
+const clientOwner = ccc.ClientPublicTestnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 
 const signers = getJoyIdSigners(
   client,
@@ -378,7 +380,9 @@ console.log("CKB Address:", address);
 import { ccc } from "@ckb-ccc/core";
 import { CkbSigner } from "@ckb-ccc/joy-id";
 
-const client = new ccc.ClientPublicMainnet();
+const clientOwner = ccc.ClientPublicMainnet.open();
+const client = clientOwner.value;
+// 不再使用时调用 `await clientOwner.dispose()`。
 const signer = new CkbSigner(client, "My DApp", "https://my-dapp.com/icon.png");
 
 await signer.connect();

--- a/packages/examples/src/backendTransfer.ts
+++ b/packages/examples/src/backendTransfer.ts
@@ -9,9 +9,11 @@ import { ccc } from "@ckb-ccc/ccc";
 import { client, signer as playgroundSigner } from "@ckb-ccc/playground";
 
 // In a real backend, you'd create a signer with a private key:
-//   const client = new ccc.ClientPublicTestnet();
+//   const clientOwner = ccc.ClientPublicTestnet.open();
+//   const client = clientOwner.value;
 //   const signer = new ccc.SignerCkbPrivateKey(client, process.env.CKB_PRIVATE_KEY!);
 //   await signer.connect();
+//   // Call `await clientOwner.dispose()` at shutdown.
 
 // For this playground demo, we use the playground signer
 const signer = playgroundSigner;

--- a/packages/faucet/libs/tap/src/tap.service.ts
+++ b/packages/faucet/libs/tap/src/tap.service.ts
@@ -1,17 +1,18 @@
 import { ccc } from "@ckb-ccc/core";
-import { Injectable, Logger } from "@nestjs/common";
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { HDKey } from "@scure/bip32";
 import { mnemonicToSeedSync } from "@scure/bip39";
 
 @Injectable()
-export class TapService {
+export class TapService implements OnModuleDestroy {
   private readonly logger = new Logger(TapService.name);
 
   private readonly rootKey: HDKey;
   private readonly pathPrefix: string;
   private readonly feeRate: number;
-  private readonly client = new ccc.ClientPublicTestnet();
+  private readonly clientOwner: ccc.Owner<ccc.ClientPublicTestnet>;
+  private readonly client: ccc.ClientPublicTestnet;
 
   constructor(configService: ConfigService) {
     const mnemonic = configService.get<string>("server_mnemonic");
@@ -26,6 +27,12 @@ export class TapService {
     this.rootKey = HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic));
     this.pathPrefix = configService.get<string>("hd_path_prefix") ?? "";
     this.feeRate = feeRate;
+    this.clientOwner = ccc.ClientPublicTestnet.open();
+    this.client = this.clientOwner.value;
+  }
+
+  async onModuleDestroy() {
+    await this.clientOwner.dispose();
   }
 
   async tapCkb(address: string, amount: string) {

--- a/packages/faucet/libs/tap/src/tap.service.ts
+++ b/packages/faucet/libs/tap/src/tap.service.ts
@@ -1,11 +1,11 @@
 import { ccc } from "@ckb-ccc/core";
-import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { HDKey } from "@scure/bip32";
 import { mnemonicToSeedSync } from "@scure/bip39";
 
 @Injectable()
-export class TapService implements OnModuleDestroy {
+export class TapService {
   private readonly logger = new Logger(TapService.name);
 
   private readonly rootKey: HDKey;
@@ -26,10 +26,6 @@ export class TapService implements OnModuleDestroy {
     this.rootKey = HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic));
     this.pathPrefix = configService.get<string>("hd_path_prefix") ?? "";
     this.feeRate = feeRate;
-  }
-
-  async onModuleDestroy(): Promise<void> {
-    await this.client.close();
   }
 
   async tapCkb(address: string, amount: string) {

--- a/packages/nip07/src/signer.test.ts
+++ b/packages/nip07/src/signer.test.ts
@@ -6,6 +6,13 @@ import { NostrAccountChangedError, Signer } from "./signer.js";
 
 const PUBLIC_KEY_A = "11".repeat(32);
 const PUBLIC_KEY_B = "22".repeat(32);
+const CLIENT = ccc.ClientPublicTestnet.new({
+  transport: {
+    request: async () => {
+      throw new Error("Unexpected request");
+    },
+  },
+});
 
 class ConnectionsRepoMemory implements ConnectionsRepo {
   constructor(public connection?: Connection) {}
@@ -53,7 +60,7 @@ describe("NIP-07 Signer connection persistence", () => {
   it("refreshes the persisted connection on every connect", async () => {
     const { getPublicKey, provider } = createProvider();
     const repo = new ConnectionsRepoMemory();
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     await signer.connect();
     getPublicKey.mockResolvedValueOnce(PUBLIC_KEY_B);
@@ -66,11 +73,11 @@ describe("NIP-07 Signer connection persistence", () => {
   it("restores the persisted connection in a recreated signer", async () => {
     const { getPublicKey, provider } = createProvider();
     const repo = new ConnectionsRepoMemory();
-    const signerA = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signerA = new Signer(CLIENT, provider, repo);
 
     await signerA.connect();
 
-    const signerB = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signerB = new Signer(CLIENT, provider, repo);
 
     expect(await signerB.isConnected()).toBe(true);
     expect(getPublicKey).toHaveBeenCalledTimes(1);
@@ -83,7 +90,7 @@ describe("NIP-07 Signer connection persistence", () => {
       publicKey: `0x${PUBLIC_KEY_A}`,
     });
     const { getPublicKey, provider } = createProvider();
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     expect(await signer.isConnected()).toBe(true);
     expect(await signer.getNostrPublicKey()).toBe(`0x${PUBLIC_KEY_A}`);
@@ -93,7 +100,7 @@ describe("NIP-07 Signer connection persistence", () => {
   it("removes the persisted connection on disconnect", async () => {
     const repo = new ConnectionsRepoMemory();
     const { provider } = createProvider();
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     await signer.connect();
     await signer.disconnect();
@@ -108,7 +115,7 @@ describe("NIP-07 Signer connection persistence", () => {
     getPublicKey
       .mockRejectedValueOnce(new Error("Rejected"))
       .mockResolvedValueOnce(PUBLIC_KEY_A);
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     await expect(signer.connect()).rejects.toThrow("Rejected");
     expect(repo.connection).toBeUndefined();
@@ -124,7 +131,7 @@ describe("NIP-07 Signer connection persistence", () => {
     });
     const { getPublicKey, provider } = createProvider();
     getPublicKey.mockRejectedValueOnce(new Error("Rejected"));
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     expect(await signer.isConnected()).toBe(true);
     await expect(signer.connect()).rejects.toThrow("Rejected");
@@ -138,7 +145,7 @@ describe("NIP-07 Signer connection persistence", () => {
       publicKey: `0x${PUBLIC_KEY_A}`,
     });
     const { provider, signEvent } = createProvider();
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     await signer.signNostrEvent(createEvent());
 
@@ -153,7 +160,7 @@ describe("NIP-07 Signer connection persistence", () => {
       publicKey: `0x${PUBLIC_KEY_A}`,
     });
     const { provider } = createProvider(PUBLIC_KEY_B);
-    const signer = new Signer(new ccc.ClientPublicTestnet(), provider, repo);
+    const signer = new Signer(CLIENT, provider, repo);
 
     await expect(signer.signNostrEvent(createEvent())).rejects.toBeInstanceOf(
       NostrAccountChangedError,

--- a/packages/playground/src/app/layoutProvider.tsx
+++ b/packages/playground/src/app/layoutProvider.tsx
@@ -1,12 +1,53 @@
 "use client";
 
 import { ccc } from "@ckb-ccc/connector-react";
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { AppProvider } from "./context";
 
 export function LayoutProvider({ children }: { children: ReactNode }) {
+  const [clientOptions, setClientOptions] =
+    useState<{ name: string; client: ccc.Client }[]>();
+
+  useEffect(() => {
+    const owner = ccc.OwnerAggregated.from([
+      ccc.ClientPublicTestnet.open(),
+      ccc.ClientPublicMainnet.open(),
+    ] as const);
+    const [testnet, mainnet] = owner.value;
+    // The clients must be opened after commit to avoid leaking aborted renders.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setClientOptions([
+      { name: "CKB Testnet", client: testnet },
+      { name: "CKB Mainnet", client: mainnet },
+    ]);
+    return () => void owner.dispose().catch(() => {});
+  }, []);
+
+  if (!clientOptions) return null;
+
   return (
-    <ccc.Provider>
+    <ccc.Provider
+      name="CCC Playground"
+      icon="/favicon.svg"
+      clientOptions={clientOptions}
+      connectorProps={{
+        style: {
+          "--background": "#1f2937",
+          "--divider": "#374151",
+          "--btn-primary": "#374151",
+          "--btn-primary-hover": "#4b5563",
+          "--btn-secondary": "#374151",
+          "--btn-secondary-hover": "#4b5563",
+          "--btn-color": "#f3f4f6",
+          "--btn-color-hover": "#fff",
+          "--icon-primary": "#f3f4f6",
+          "--icon-secondary": "#9ca3af",
+          "--tip-color": "#9ca3af",
+          "--tip-color-hover": "#d1d5db",
+          color: "#f3f4f6",
+        } as React.CSSProperties,
+      }}
+    >
       <AppProvider>{children}</AppProvider>
     </ccc.Provider>
   );

--- a/packages/playground/src/app/page.tsx
+++ b/packages/playground/src/app/page.tsx
@@ -29,6 +29,30 @@ import { execute } from "./execute";
 import { About } from "./tabs/About";
 import { Console } from "./tabs/Console";
 
+function openWebSocket(url: string): ccc.Owner<WebSocket> {
+  const socket = new WebSocket(url);
+  return new ccc.OwnerUnique(socket, async (socket) => {
+    if (socket.readyState === socket.CLOSED) return;
+
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        window.clearTimeout(timeout);
+        socket.removeEventListener("close", finish);
+        resolve();
+      };
+      const timeout = window.setTimeout(finish, 1000);
+      socket.addEventListener("close", finish, { once: true });
+      socket.onopen = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      socket.onmessage = null;
+      if (socket.readyState !== socket.CLOSING) {
+        socket.close();
+      }
+    });
+  });
+}
+
 async function shareToNostr(
   client: ccc.Client,
   relays: string[],
@@ -52,26 +76,36 @@ async function shareToNostr(
   const sent = (
     await Promise.all(
       relays.map(async (relay) => {
-        const socket = new WebSocket(relay);
-        const res = await new Promise<string | undefined>((resolve) => {
-          setTimeout(resolve, 5000);
-          socket.onclose = () => {
-            resolve(undefined);
-          };
-          socket.onmessage = (event) => {
-            const data = JSON.parse(event.data as string);
-            if (data[0] === "OK" && data[1] === signedEvent.id && data[2]) {
-              resolve(relay);
-            } else {
+        const socketOwner = openWebSocket(relay);
+        const socket = socketOwner.value;
+        let timeout: number | undefined;
+        try {
+          return await new Promise<string | undefined>((resolve) => {
+            timeout = window.setTimeout(resolve, 5000);
+            socket.onclose = () => {
               resolve(undefined);
-            }
-          };
-          socket.onopen = () => {
-            socket.send(JSON.stringify(["EVENT", signedEvent]));
-          };
-        });
-        socket.close();
-        return res;
+            };
+            socket.onerror = () => resolve(undefined);
+            socket.onmessage = (event) => {
+              try {
+                const data = JSON.parse(event.data as string);
+                if (data[0] === "OK" && data[1] === signedEvent.id && data[2]) {
+                  resolve(relay);
+                } else {
+                  resolve(undefined);
+                }
+              } catch (_err) {
+                resolve(undefined);
+              }
+            };
+            socket.onopen = () => {
+              socket.send(JSON.stringify(["EVENT", signedEvent]));
+            };
+          });
+        } finally {
+          window.clearTimeout(timeout);
+          await socketOwner.dispose();
+        }
       }),
     )
   ).filter((r) => r !== undefined);
@@ -139,34 +173,59 @@ async function getFromNEvent(
     throw new Error("Invalid nevent");
   }
 
-  return Promise.any(relays.map((relay) => getFromNostr(relay, eventId)));
+  const aborter = new AbortController();
+  const requests = relays.map((relay) =>
+    getFromNostr(relay, eventId, aborter.signal),
+  );
+  try {
+    return await Promise.any(requests);
+  } finally {
+    aborter.abort();
+    await Promise.allSettled(requests);
+  }
 }
 
-async function getFromNostr(relayUrl: string, id: string): Promise<string> {
-  const socket = new WebSocket(relayUrl);
-
-  const res = await new Promise<string>((resolve, reject) => {
-    setTimeout(() => reject("Timeout"), 10000);
-    socket.onclose = () => {
-      reject("Connection closed");
-    };
-    socket.onmessage = (event) => {
-      const data = JSON.parse(event.data as string);
-      if (data[0] === "EVENT" && data[1] === "1") {
-        resolve(data[2].content);
-      } else if (data[0] === "EOSE") {
-        reject("Event not found");
-      } else {
-        reject(JSON.stringify(event.data));
-      }
-    };
-    socket.onopen = () => {
-      socket.send(JSON.stringify(["REQ", "1", { ids: [id] }]));
-    };
-  });
-  socket.close();
-
-  return res;
+async function getFromNostr(
+  relayUrl: string,
+  id: string,
+  signal: AbortSignal,
+): Promise<string> {
+  const socketOwner = openWebSocket(relayUrl);
+  const socket = socketOwner.value;
+  let timeout: number | undefined;
+  let abort: (() => void) | undefined;
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      timeout = window.setTimeout(() => reject(new Error("Timeout")), 10000);
+      abort = () => reject(new Error("Aborted"));
+      signal.addEventListener("abort", abort, { once: true });
+      socket.onclose = () => {
+        reject(new Error("Connection closed"));
+      };
+      socket.onerror = () => reject(new Error("Connection error"));
+      socket.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data as string);
+          if (data[0] === "EVENT" && data[1] === "1") {
+            resolve(data[2].content);
+          } else if (data[0] === "EOSE") {
+            reject(new Error("Event not found"));
+          } else {
+            reject(new Error(JSON.stringify(event.data)));
+          }
+        } catch (err) {
+          reject(err);
+        }
+      };
+      socket.onopen = () => {
+        socket.send(JSON.stringify(["REQ", "1", { ids: [id] }]));
+      };
+    });
+  } finally {
+    window.clearTimeout(timeout);
+    if (abort) signal.removeEventListener("abort", abort);
+    await socketOwner.dispose();
+  }
 }
 
 const DEFAULT_NOSTR_RELAYS = [

--- a/packages/playground/src/app/page.tsx
+++ b/packages/playground/src/app/page.tsx
@@ -293,8 +293,8 @@ export default function Home() {
             onClick={() =>
               setClient(
                 isTestnet
-                  ? new ccc.ClientPublicMainnet()
-                  : new ccc.ClientPublicTestnet(),
+                  ? ccc.ClientPublicMainnet.open()
+                  : ccc.ClientPublicTestnet.open(),
               )
             }
           >

--- a/packages/playground/src/app/tabs/enhanceDisplay.tsx
+++ b/packages/playground/src/app/tabs/enhanceDisplay.tsx
@@ -56,21 +56,16 @@ export async function enhanceDisplay(
     typeof msg === "string" &&
     (msg.startsWith("ckb") || msg.startsWith("ckt"))
   ) {
-    const mainnetClient = new ccc.ClientPublicMainnet();
-    const testnetClient = new ccc.ClientPublicTestnet();
     try {
       return (
         <Address
           address={await ccc.Address.fromString(msg, {
-            ckb: mainnetClient,
-            ckt: testnetClient,
+            ckb: new ccc.ClientPublicMainnet(),
+            ckt: new ccc.ClientPublicTestnet(),
           })}
         />
       );
-    } catch (_err) {
-    } finally {
-      await Promise.all([mainnetClient.close(), testnetClient.close()]);
-    }
+    } catch (_err) {}
   }
 
   if (msg instanceof ccc.Signer) {

--- a/packages/playground/src/app/tabs/enhanceDisplay.tsx
+++ b/packages/playground/src/app/tabs/enhanceDisplay.tsx
@@ -56,16 +56,17 @@ export async function enhanceDisplay(
     typeof msg === "string" &&
     (msg.startsWith("ckb") || msg.startsWith("ckt"))
   ) {
+    const owner = msg.startsWith("ckb")
+      ? ccc.ClientPublicMainnet.open()
+      : ccc.ClientPublicTestnet.open();
     try {
       return (
-        <Address
-          address={await ccc.Address.fromString(msg, {
-            ckb: new ccc.ClientPublicMainnet(),
-            ckt: new ccc.ClientPublicTestnet(),
-          })}
-        />
+        <Address address={await ccc.Address.fromString(msg, owner.value)} />
       );
-    } catch (_err) {}
+    } catch (_err) {
+    } finally {
+      await owner.dispose();
+    }
   }
 
   if (msg instanceof ccc.Signer) {

--- a/packages/spore/__examples__/createDobCluster.test.ts
+++ b/packages/spore/__examples__/createDobCluster.test.ts
@@ -1,7 +1,10 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { createSporeCluster, dob } from "../index.js";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 function generateClusterDescriptionUnderDobProtocol(
   client: ccc.Client,
@@ -143,7 +146,7 @@ describe("createCluster [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should create a Cluster cell under DOB protocol", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/createDobSpore.test.ts
+++ b/packages/spore/__examples__/createDobSpore.test.ts
@@ -1,13 +1,16 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { createSpore } from "../src/index.js";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("createSpore [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should create a Spore cell under DOB protocol", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/createSporeWithoutCluster.test.ts
+++ b/packages/spore/__examples__/createSporeWithoutCluster.test.ts
@@ -1,14 +1,17 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
 import "dotenv/config";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { createSpore } from "../index.js";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("createSpore [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should create a simple Spore cell without cluster", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/meltSpore.test.ts
+++ b/packages/spore/__examples__/meltSpore.test.ts
@@ -1,13 +1,16 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { meltSpore } from "..";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("meltSpore [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should melt a Spore cell by sporeId", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/meltThenCreateSpore.test.ts
+++ b/packages/spore/__examples__/meltThenCreateSpore.test.ts
@@ -1,13 +1,16 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { createSpore, meltSpore } from "..";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("meltSpore [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should melt a Spore cell by sporeId", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/searchClusters.test.ts
+++ b/packages/spore/__examples__/searchClusters.test.ts
@@ -1,12 +1,15 @@
 import { ccc } from "@ckb-ccc/core";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { findSporeClustersBySigner } from "../cluster";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("searchClusters [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should search multiple Cluster cells under private key", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/searchSpores.test.ts
+++ b/packages/spore/__examples__/searchSpores.test.ts
@@ -1,12 +1,15 @@
 import { ccc } from "@ckb-ccc/core";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { findSporesBySigner } from "../spore";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("searchSpores [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should search multiple Spore cells under private key", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/transferCluster.test.ts
+++ b/packages/spore/__examples__/transferCluster.test.ts
@@ -1,13 +1,16 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { transferSporeCluster } from "..";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("transferCluster [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should transfer a Cluster cell by sporeId", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/spore/__examples__/transferSpore.test.ts
+++ b/packages/spore/__examples__/transferSpore.test.ts
@@ -1,13 +1,16 @@
 import { ccc } from "@ckb-ccc/core";
 import { JsonRpcTransformers } from "@ckb-ccc/core/advanced";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { transferSpore } from "../index.js";
+
+const clientOwner = ccc.ClientPublicTestnet.open();
+afterAll(() => clientOwner.dispose());
 
 describe("transferSpore [testnet]", () => {
   expect(process.env.PRIVATE_KEY).toBeDefined();
 
   it("should transfer a Spore cell by sporeId", async () => {
-    const client = new ccc.ClientPublicTestnet();
+    const client = clientOwner.value;
     const signer = new ccc.SignerCkbPrivateKey(
       client,
       process.env.PRIVATE_KEY!,

--- a/packages/ssri/package.json
+++ b/packages/ssri/package.json
@@ -24,7 +24,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "test": "jest",
+    "test": "vitest",
+    "test:ci": "vitest run",
     "build": "tsdown",
     "lint": "tsc --noEmit && eslint ./src",
     "format": "prettier --write . && eslint --fix ./src"
@@ -40,7 +41,8 @@
     "tsdown": "^0.22.3",
     "@typescript/native": "npm:typescript@^7.0.2",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "typescript-eslint": "^8.61.1"
+    "typescript-eslint": "^8.61.1",
+    "vitest": "^4.1.9"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ssri/src/executor.test.ts
+++ b/packages/ssri/src/executor.test.ts
@@ -1,0 +1,77 @@
+import { ccc } from "@ckb-ccc/core";
+import { describe, expect, it, vi } from "vitest";
+import { ExecutorErrorExecutionFailed, ExecutorJsonRpc } from "./executor.js";
+
+describe("ExecutorJsonRpc ownership", () => {
+  it("creates an Executor that borrows an externally provided Transport", async () => {
+    const request = vi.fn<ccc.JsonRpcTransport["request"]>(async (payload) => ({
+      id: payload.id,
+      jsonrpc: "2.0",
+      result: { content: "0x", cell_deps: [] },
+    }));
+    const executor = ExecutorJsonRpc.new({ transport: { request } });
+
+    await expect(
+      executor.runScript(
+        { txHash: `0x${"00".repeat(32)}`, index: 0 },
+        "SSRI.version",
+        [],
+      ),
+    ).resolves.toMatchObject({ res: "0x", cellDeps: [] });
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("maps SSRI execution errors for borrowed Transports", async () => {
+    const executor = ExecutorJsonRpc.new({
+      transport: {
+        request: async (payload) => ({
+          id: payload.id,
+          jsonrpc: "2.0",
+          error: { code: 1003, message: "execution failed" },
+        }),
+      },
+    });
+
+    await expect(
+      executor.runScript(
+        { txHash: `0x${"00".repeat(32)}`, index: 0 },
+        "SSRI.version",
+        [],
+      ),
+    ).rejects.toThrow(ExecutorErrorExecutionFailed);
+  });
+
+  it("keeps legacy constructor Requestor injection compatible", () => {
+    const requestor = ccc.RequestorJsonRpc.new({
+      transport: {
+        request: async (payload) => ({
+          id: payload.id,
+          jsonrpc: "2.0",
+          result: "ok",
+        }),
+      },
+    });
+
+    const executor = new ExecutorJsonRpc("https://example.com", { requestor });
+
+    expect(executor.requestor).toBe(requestor);
+    expect(executor.url).toBe("https://example.com");
+  });
+
+  it("opens an owned Executor", async () => {
+    const owner = ExecutorJsonRpc.open({ urls: ["ws://example.com"] });
+    const executor = owner.value;
+
+    expect(executor).toBeInstanceOf(ExecutorJsonRpc);
+
+    await owner.dispose();
+    expect(() => owner.value).toThrow(
+      "Cannot access a moved or disposed Owner",
+    );
+    await expect(
+      executor.requestor.requestPayload(
+        executor.requestor.buildPayload("test", []),
+      ),
+    ).rejects.toThrow("Cannot use a disposed JsonRpcTransportWebSocket");
+  });
+});

--- a/packages/ssri/src/executor.ts
+++ b/packages/ssri/src/executor.ts
@@ -38,6 +38,29 @@ export class ExecutorErrorDecode extends Error {
   }
 }
 
+function handleJsonRpcError(errAny: unknown): never {
+  if (
+    typeof errAny !== "object" ||
+    errAny === null ||
+    !("code" in errAny) ||
+    typeof errAny.code !== "number"
+  ) {
+    throw new ExecutorErrorUnknown(JSON.stringify(errAny));
+  }
+
+  if (errAny.code === 1003 || errAny.code === 1004) {
+    if ("message" in errAny && typeof errAny.message === "string") {
+      throw new ExecutorErrorExecutionFailed(errAny.message);
+    }
+    throw new ExecutorErrorExecutionFailed();
+  }
+
+  if ("message" in errAny && typeof errAny.message === "string") {
+    throw new ExecutorErrorUnknown(errAny.message);
+  }
+  throw new ExecutorErrorUnknown();
+}
+
 export type ContextCode =
   | undefined
   | {
@@ -93,47 +116,79 @@ export abstract class Executor {
   }
 }
 
+export type ExecutorJsonRpcConfig = ccc.RequestorJsonRpcConfig & {
+  /**
+   * @deprecated Requestor injection is supported only by the legacy
+   * constructor. Use a borrowed Transport with `ExecutorJsonRpc.new` or let
+   * `ExecutorJsonRpc.open` create one.
+   */
+  requestor?: ccc.RequestorJsonRpc;
+};
+
 export class ExecutorJsonRpc extends Executor {
   public readonly requestor: ccc.RequestorJsonRpc;
 
   /**
+   * The external server URL passed to the legacy constructor.
+   * @deprecated Use a borrowed Transport with {@link ExecutorJsonRpc.new} or
+   * let {@link ExecutorJsonRpc.open} create Transports.
+   */
+  public get url(): string {
+    return this.url_;
+  }
+
+  /**
    * Creates an instance of SSRI executor through Json RPC.
-   * @param {string} [url] - The external server URL.
+   * @param url_ - The external server URL.
+   * @param config - JSON-RPC request configuration.
+   * @deprecated Use {@link ExecutorJsonRpc.new} with a borrowed Transport or
+   * {@link ExecutorJsonRpc.open} when creating Transports.
    */
   constructor(
-    url: string,
-    config?: ccc.RequestorJsonRpcConfig & { requestor?: ccc.RequestorJsonRpc },
+    private readonly url_: string,
+    config?: ExecutorJsonRpcConfig,
   ) {
     super();
 
-    this.requestor =
-      config?.requestor ??
-      new ccc.RequestorJsonRpc(url, config, (errAny) => {
-        if (
-          typeof errAny !== "object" ||
-          errAny === null ||
-          !("code" in errAny) ||
-          typeof errAny.code !== "number"
-        ) {
-          throw new ExecutorErrorUnknown(JSON.stringify(errAny));
-        }
-
-        if (errAny.code === 1003 || errAny.code === 1004) {
-          if ("message" in errAny && typeof errAny.message === "string") {
-            throw new ExecutorErrorExecutionFailed(errAny.message);
-          }
-          throw new ExecutorErrorExecutionFailed();
-        }
-
-        if ("message" in errAny && typeof errAny.message === "string") {
-          throw new ExecutorErrorUnknown(errAny.message);
-        }
-        throw new ExecutorErrorUnknown();
+    const requestor = config?.requestor;
+    if (requestor) {
+      this.requestor = requestor;
+    } else if (config?.transport) {
+      this.requestor = ccc.RequestorJsonRpc.new({
+        transport: config.transport,
+        maxConcurrent: config.maxConcurrent,
+        onError: handleJsonRpcError,
       });
+    } else {
+      // Legacy constructor intentionally discards ownership.
+      this.requestor = ccc.RequestorJsonRpc.open({
+        urls: [this.url_, ...(config?.fallbacks ?? [])],
+        timeout: config?.timeout,
+        maxConcurrent: config?.maxConcurrent,
+        onError: handleJsonRpcError,
+      }).value;
+    }
   }
 
-  get url() {
-    return this.requestor.url;
+  /** Creates an Executor that borrows an existing Transport. */
+  static new(
+    config: Omit<Parameters<typeof ccc.RequestorJsonRpc.new>[0], "onError">,
+  ): ExecutorJsonRpc {
+    const requestor = ccc.RequestorJsonRpc.new({
+      ...config,
+      onError: handleJsonRpcError,
+    });
+    return new ExecutorJsonRpc("", { requestor });
+  }
+
+  /** Opens an Executor with ownership of its default Transports. */
+  static open(
+    config: Omit<Parameters<typeof ccc.RequestorJsonRpc.open>[0], "onError">,
+  ): ccc.Owner<ExecutorJsonRpc> {
+    return ccc.RequestorJsonRpc.open({
+      ...config,
+      onError: handleJsonRpcError,
+    }).map((requestor) => new ExecutorJsonRpc("", { requestor }));
   }
 
   /* Calls a method on the SSRI executor through SSRI Server.

--- a/packages/ssri/vitest.config.mts
+++ b/packages/ssri/vitest.config.mts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      include: ["src/**/*.ts"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1298,6 +1298,9 @@ importers:
       typescript-eslint:
         specifier: ^8.61.1
         version: 8.67.0(@typescript/typescript6@6.0.2)(eslint@10.8.1(jiti@2.7.0))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(vite@7.3.5(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/tests:
     dependencies:

--- a/skills/ckb-ccc-signer-setup/SKILL.md
+++ b/skills/ckb-ccc-signer-setup/SKILL.md
@@ -60,7 +60,7 @@ function ConnectButton() {
 
 ## Building a Node.js backend script
 
-1. **Import and connect** — Install `@ckb-ccc/shell`. Create client: `new ccc.ClientPublicTestnet()` or `ClientPublicMainnet()`.
+1. **Import and connect** — Install `@ckb-ccc/shell`. Open an owned client with `ccc.ClientPublicTestnet.open()` or `ccc.ClientPublicMainnet.open()`, retain the returned Owner, and dispose it at shutdown.
 2. **Create signer** — `new ccc.SignerCkbPrivateKey(client, process.env.CKB_PRIVATE_KEY!)`. Never hardcode keys. (Validate environment variable exists first—see code example below)
 3. **Check connection** — Some signers require `await signer.connect()`. Check with `await signer.isConnected()` if operations fail unexpectedly.
 4. **Query data** — `await signer.getRecommendedAddress()`, `await signer.getBalance()`, `for await (const cell of client.findCellsByLock(...))`.
@@ -71,7 +71,8 @@ function ConnectButton() {
 import { ccc } from "@ckb-ccc/shell";
 
 // Always load private key from environment — never hardcode
-const client = new ccc.ClientPublicTestnet(); // or ClientPublicMainnet
+const clientOwner = ccc.ClientPublicTestnet.open(); // or ccc.ClientPublicMainnet.open()
+const client = clientOwner.value;
 
 const privateKey = process.env.CKB_PRIVATE_KEY;
 if (!privateKey) throw new Error("CKB_PRIVATE_KEY is required");
@@ -81,6 +82,8 @@ await signer.connect();
 
 const address = await signer.getRecommendedAddress(); // "ckt1q..." or "ckb1q..."
 const balance = await signer.getBalance(); // bigint in Shannon
+
+await clientOwner.dispose();
 ```
 
 **TypeScript config** — `@ckb-ccc/shell` ships ESM only:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,6 +4,7 @@ const packages = [
   "packages/core",
   "packages/did-ckb",
   "packages/nip07",
+  "packages/ssri",
   "packages/type-id",
 ];
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

- [x] I have read the [**Contributing Guidelines**](CONTRIBUTING.md)

Replaced #487. Things are more complicated than I thought.

Adding `Client/Requestor.close` will soon mess up ownerships and make lifetime management terrible. This PR introduces the explicit `Owner` ownership semantic, which clarified the responsibility of disposing instances.